### PR TITLE
Add MindMac to ChatGPT Applications section

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -74,6 +74,7 @@
 | WebChatGPT |开源程序，给chatgpt扩展联网的能力 </br> 视频介绍：[B站视频：可以让ChatGPT直接联网的扩展程序](https://www.bilibili.com/video/BV1bY4y1C7N3) | [GitHub](https://github.com/qunash/chatgpt-advanced) ![GitHub Repo stars](https://img.shields.io/github/stars/qunash/chatgpt-advanced?style=social)| 免费|
 | AIPRM for ChatGPT |浏览器插件，提供一系列精选ChatGPT 指令模板，甚至还能够自己创建，还可以调整AI 语气和写作风格 </br>B站视频：[集大成者！ChatGPT百宝箱，内置多种功能，所见即所得！](https://www.bilibili.com/video/BV1LT411S7GK)| [URL](https://chrome.google.com/webstore/detail/aiprm-for-chatgpt/ojnbohmppadfgpejeebfnmnknjdlckgj) | 免费|
 | GPTCache |⚡ GPTCache 是一个用于创建语义缓存以存储来自 LLM 查询的响应的库，类似于aigc场景中的redis。 它可用于降低依赖 LLM 服务（如ChatGPT）的成本，同时也可以有效减少服务响应时间，因为大模型推理一般都比较耗时。| [GitHub](https://github.com/zilliztech/GPTCache) ![GitHub Repo stars](https://img.shields.io/github/stars/zilliztech/GPTCache?style=social)| 免费|
+| MindMac | 功能丰富、隐私第一的 macOS 原生 ChatGPT 应用程序，可在一个地方使用 OpenAI, Azure OpenAI, Anthropic Claude, OpenRouter，旨在实现最大生产力。 目前有 15 种语言版本。| [URL](https://mindmac.app/) | 免费，有付费升级版 |
 
 ### 国内可使用的ChatGPT镜像站点
 | 名称 | 说明 | 链接 |

--- a/README-IN.md
+++ b/README-IN.md
@@ -50,6 +50,7 @@
 | वेबचैटजीपीटी | खुला स्रोत, नेटवर्किंग की क्षमता को चैटजीपीटी तक विस्तारित करें | [GitHub](https://github.com/qunash/chatgpt-advanced) </br>![GitHub Repo stars](https://img.shields.io/github/stars/qunash/chatgpt-advanced?style=social)| मुफ्त |
 | चैटजीपीटी के लिए AIPRM | ब्राउज़र प्लग-इन, चयनित चैटजीपीटी निर्देश टेम्पलेट की एक श्रृंखला प्रदान करने, और यहाँ तक कि आपके खुद के बना सकते हैं, और एआई टोन और लेखन शैली को समायोजित कर सकते हैं | [URL](https://chrome.google.com/webstore/detail/aiprm-for-chatgpt/ojnbohmppadfgpejeebfnmnknjdlckgj) | मुफ्त |
 | जीपीटीकैश | ⚡ जीपीटीकैश एक लाइब्रेरी है जिसका उपयोग एलएलएम क्वेरियों से आये उत्तरों को समांतर चैच के रूप में स्थान देने के लिए किया जाता है। यह चैट एप्लिकेशनों की गति और लागत को कम करने में मदद करने के लिए उपयोग किया जा सकता है जिनका आधार एलएलएम सेवा पर होता है। और यह एक ऐग्सी स्थिति में रेडिस के समान होता है।| [Github](https://github.com/zilliztech/GPTCache) </br>![GitHub Repo stars](https://img.shields.io/github/stars/zilliztech/GPTCache?style=social)| मुफ्त |
+| माइंडमैक | अधिकतम उत्पादकता के लिए डिज़ाइन किए गए OpenAI, Azure OpenAI, Anthropic Claude, OpenRouter सभी को एक ही स्थान पर उपयोग करने के लिए macOS के लिए सुविधा संपन्न और गोपनीयता-पहला देशी ChatGPT ऐप। वर्तमान में 15 भाषाओं में उपलब्ध है। | [URL](https://mindmac.app/) | मुफ्त, भुगतान के साथ अपग्रेड |
 
 ### विभिन्न भाषामॉडलों का एकत्रण करने वाले अनुप्रयोग
 | नाम | विवरण | लिंक | शुल्क | 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This repo collects AI-related utilities.
 | WebChatGPT | Open source, expand the ability of networking to chatgpt | [GitHub](https://github.com/qunash/chatgpt-advanced) </br>![GitHub Repo stars](https://img.shields.io/github/stars/qunash/chatgpt-advanced?style=social)| Free|
 | AIPRM for ChatGPT |Browser plug-in, providing a series of selected ChatGPT instruction templates, and even creating your own, and adjusting AI tone and writing style| [URL](https://chrome.google.com/webstore/detail/aiprm-for-chatgpt/ojnbohmppadfgpejeebfnmnknjdlckgj) | Free|
 | GPTCache |⚡ GPTCache is a library for creating semantic cache to store responses from LLM queries. It can be used to speed up and lower the cost of chat applications that rely on the LLM service. And it's similar to redis in an aigc scenario.| [Github](https://github.com/zilliztech/GPTCache) </br>![GitHub Repo stars](https://img.shields.io/github/stars/zilliztech/GPTCache?style=social)| Free|
+| MindMac | Feature-rich & privacy-first native ChatGPT app for macOS to use OpenAI, Azure OpenAI, Anthropic Claude, OpenRouter all in one place, designed for maximum productivity. Currently available in 15 languages. | [URL](https://mindmac.app/) | Free, with paid upgrades|
 
 ### Applications that integrate multiple LLMs
 | Name | Description | Links | Fees | 


### PR DESCRIPTION
Hi @ikaijua,  I added MindMac, a feature-rich & privacy-first native ChatGPT app for macOS to use OpenAI, Azure OpenAI, Anthropic Claude, OpenRouter all in one place. Please help to review this PR. Thank you!