### PR TITLE
adding mutahunter to programming development

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ This repo collects AI-related utilities.
 |flappy|Production-Ready LLM Agent SDK for Every Developer|[GitHub](https://github.com/pleisto/flappy) ![GitHub Repo stars](https://img.shields.io/github/stars/pleisto/flappy.svg?style=social) |Free|
 | Plandex | Open source, terminal-based AI programming engine for complex tasks | [GitHub](https://github.com/plandex-ai/plandex) ![GitHub Repo stars](https://img.shields.io/github/stars/plandex-ai/plandex?style=social)| Free |
 | Mistral/Codestral|[Empowering developers and democratising coding with Mistral AI.](https://mistral.ai/news/codestral/), models:https://huggingface.co/mistralai/Codestral-22B-v0.1|[URL](https://chat.mistral.ai/chat)|Free|
+| MutahunterAI | Accelerate developer productivity and code security with our open-source AI. | [GitHub](https://github.com/codeintegrity-ai/mutahunter) ![GitHub Repo stars](https://img.shields.io/github/stars/codeintegrity-ai/mutahunter?style=social)| Free |
 
 ### Translation
 | Name | Description | Links | Fees |  


### PR DESCRIPTION
Adding Mutahunter to programming development section

TLDR;

Mutahunter is an open-source tool that boosts developer productivity by accurately identifying code bugs and generating test cases to specifically test against these code bugs.

Problem: 

Everyone wants to ship code faster, but as code grows more complex so does software testing. Software teams spend 40% of their dev time software testing.  Software testing is the biggest bottleneck to shipping code and the recent Crowdstrike incident has shown has shown that there are catastrophic consequences from skipping good software testing. 

Solution:

Use Mutahunter to generate unit tests for your codebase, that specifically target the code vulnerabilities. By targeting the exact weaknesses in the code, we boost developer productivity.
 
What makes us different?
* Unlike copilots which blindly generates test cases for your code, Mutahunter makes use of our mutation testing engine to generate unit tests that specifically target the vulnerabilities in your code
* We are open-source and support all major languages.
* We can be used locally or can be integrated into any CI/CD runner as part of your existing workflow.
* You can use Mutahunter with your own LLM APIs for privacy. 
