### PR TITLE
Add aicodeprep-gui to AI tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ This repo collects awesome AI tools.
 |flappy|Production-Ready LLM Agent SDK for Every Developer|[GitHub](https://github.com/pleisto/flappy) ![GitHub Repo stars](https://img.shields.io/github/stars/pleisto/flappy.svg?style=social) |Free|
 | Plandex | Open source, terminal-based AI programming engine for complex tasks | [GitHub](https://github.com/plandex-ai/plandex) ![GitHub Repo stars](https://img.shields.io/github/stars/plandex-ai/plandex?style=social)| Free |
 | Mistral/Codestral|[Empowering developers and democratising coding with Mistral AI.](https://mistral.ai/news/codestral/), models:https://huggingface.co/mistralai/Codestral-22B-v0.1|[URL](https://chat.mistral.ai/chat)|Free|
+| aicodeprep-gui | Cross-platform context maker app with UI. For fast sharing project code context to AI Studio, ChatGPT, GLM 4.5, Qwen3's web chat interfaces which usually will get better results from AI models compared to agents (tools and MCP dumb them down). Removes the friction when going from IDE/project <--> web chat interfaces. UI is for fast selecting code files or let it auto smart select, generate context block to clipboard, and paste into web chat. Preset buttons for common prompts/questions. One line install with pipx install aicodeprep-gui | [URL](https://wuu73.org/aicp) [GitHub](https://github.com/detroittommy879/aicodeprep-gui) ![GitHub Repo stars](https://img.shields.io/github/stars/detroittommy879/aicodeprep-gui.svg?style=social) | Free or Pro |
+
 
 ### AI Image Creation
 | Name | Description | Links | Fees | 


### PR DESCRIPTION
Added to Programming Development section. It is a free tool similar to the ones that work on command line but opens up a UI to make it easier to select which files you want to give to an AI, for coding context. Especially useful when you can't get any of the agent tools to fix a bug.. you can load it by typing 'aicp' in terminal, generate context block with prompt about the bug, and paste it into any of the many native AI web chat interfaces and usually get a better response/better chance of it being able to figure out a solution. Sometimes, giving AI models too much info about tools or MCP servers (like the giant prompts sent by any of the agentic coding tools) makes them less able to solve your problems. That is where this comes in handy. Doesn't replace those tools but helps along side them.