### PR TITLE
Add Price Per Token to LLM Leaderboard section

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 |Artificial Analysis|Artificial Analysis is a platform that provides AI model and service provider comparisons and benchmarks to help users make informed decisions when choosing AI models and service providers. The platform provides comparative data on a wide range of popular AI models, including OpenAI's GPT-4, Meta's Llama 3, and Anthropic's Claude series, covering performance metrics such as response time, latency, and cost.|[URL](https://artificialanalysis.ai/)|Free|
 |LiveCodeBench|LiveCodeBench is a holistic and contamination-free evaluation benchmark of LLMs for code that continuously collects new problems over time. Particularly, LiveCodeBench also focuses on broader code-related capabilities, such as self-repair, code execution, and test output prediction, beyond mere code generation. |[URL](https://livecodebench.github.io/leaderboard.html)|Free|
 |LLM Stats|LLM Stats, the most comprehensive LLM leaderboard, benchmarks and compares API models using daily‑updated, open‑source community data on capability, price, speed, and context length.|[URL](https://llm-stats.com/)|Free|
+|Price Per Token|Compare LLM API pricing across 200+ models from OpenAI, Anthropic, Google, and more. Includes token counters, cost calculators, and benchmark comparisons.|[URL](https://pricepertoken.com/)|Free|
 
 ### GPT LLMs Applications
 | Name | Description | Links | Fees | 


### PR DESCRIPTION
Adding Price Per Token (https://pricepertoken.com) to the LLM Leaderboard section.

**Why this addition is valuable:**
- Covers 200+ AI models with real-time pricing data
- Includes token counter and cost calculator tools  
- Compares pricing across all major providers (OpenAI, Anthropic, Google, Meta, etc.)
- Free to use