### PR TITLE
Add GEO/AEO Tracker - open-source AI visibility dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | Harbor | Effortlessly run LLM backends, APIs, frontends, and services with one command. | [GitHub](https://github.com/av/harbor) </br> ![GitHub Repo stars](https://img.shields.io/github/stars/av/harbor?style=social)|  Free |
 |gemini-fullstack-langgraph-quickstart|Get started with building Fullstack Agents using Gemini 2.5 and LangGraph|[Github](https://github.com/google-gemini/gemini-fullstack-langgraph-quickstart) ![GitHub Repo stars](https://img.shields.io/github/stars/google-gemini/gemini-fullstack-langgraph-quickstart?style=social)|Free|
 |NoteGPT|NoteGPT is a smart note-taking tool that can record, transcribe, and summarize various content, such as meetings, lectures, podcasts, YouTube videos, news briefings, and articles.| [URL](https://notegpt.io/) | Free/Paid |
+|GEO/AEO Tracker|Open-source, local-first AI visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.|[URL](https://llm-tracker-three.vercel.app/) <br> [Github](https://github.com/danishashko/geo-aeo-tracker) ![GitHub Repo stars](https://img.shields.io/github/stars/danishashko/geo-aeo-tracker?style=social)| Free |
 
 ### Programming Development
 | Name | Description | Links | Fees |  


### PR DESCRIPTION
## Adding GEO/AEO Tracker

[GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) is an open-source, local-first AI visibility intelligence dashboard added to the **GPT LLMs Applications** section.

**What it does:** Tracks brand mentions across 6 AI/LLM engines  ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok.

**Key features:**
- Open-source, MIT License
- BYOK  $0/month vs. $200-500/month paid tools
- Local-first (IndexedDB  no data leaves browser)
- 12-tab dashboard with visibility scoring, citation analysis, competitor battlecards
- Self-hosted on Vercel

**Live demo:** https://llm-tracker-three.vercel.app/