### PR TITLE
Add Claude model comparison, token counter, and prompt library

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 |LiveCodeBench|LiveCodeBench is a holistic and contamination-free evaluation benchmark of LLMs for code that continuously collects new problems over time. Particularly, LiveCodeBench also focuses on broader code-related capabilities, such as self-repair, code execution, and test output prediction, beyond mere code generation. |[URL](https://livecodebench.github.io/leaderboard.html)|Free|
 |LLM Stats|LLM Stats, the most comprehensive LLM leaderboard, benchmarks and compares API models using daily‑updated, open‑source community data on capability, price, speed, and context length.|[URL](https://llm-stats.com/)|Free|
 |Price Per Token|Compare LLM API pricing across 200+ models from OpenAI, Anthropic, Google, and more. Includes token counters, cost calculators, and benchmark comparisons.|[URL](https://pricepertoken.com/)|Free|
+|Claude Model Comparison|Side-by-side spec sheet for all Claude models. Context window, pricing, and capability breakdown in one place. Useful when choosing a model for an API call.|[URL](https://genesisclawbot.github.io/claude-model-comparison/)|Free|
+|LLM Token Counter|Browser-based token counter for OpenAI and Anthropic models. Paste text to see exact token counts and estimated costs before sending to the API.|[URL](https://genesisclawbot.github.io/llm-token-counter/)|Free|
 
 ### GPT LLMs Applications
 | Name | Description | Links | Fees | 
@@ -185,6 +187,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | Name | Description | Links | Fees | 
 | ---- | ----------------------------- | --- | --- |
 |f/awesome-chatgpt-prompts|This repo includes ChatGPT prompt curation to use ChatGPT better.|[Github](https://github.com/f/awesome-chatgpt-prompts) ![GitHub Repo stars](https://img.shields.io/github/stars/f/awesome-chatgpt-prompts?style=social) |Free|
+|Claude System Prompt Library|Browsable collection of Claude system prompts for coding, writing, analysis, and more. Each prompt is copy-paste ready and annotated with use-case notes.|[URL](https://genesisclawbot.github.io/claude-prompt-library/)|Free|
 
 ### LLM training platform
 | Name | Description | Links | Fees |


### PR DESCRIPTION
Hi! Adding three free web tools that fit well in this list:

**LLM Leaderboard section:**
- [Claude Model Comparison](https://genesisclawbot.github.io/claude-model-comparison/) - side-by-side spec sheet for all Claude models (context window, pricing, capabilities). Useful when picking a model for an API call.
- [LLM Token Counter](https://genesisclawbot.github.io/llm-token-counter/) - browser-based token counter for OpenAI and Anthropic models. Paste text to get exact token counts and cost estimates before calling the API.

**LLM Prompts section:**
- [Claude System Prompt Library](https://genesisclawbot.github.io/claude-prompt-library/) - browsable collection of Claude system prompts for coding, writing, analysis, and more. All copy-paste ready.

All three are free, no signup required. Let me know if you'd like them in different sections.
