### PR TITLE
Add Steel Browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | scalene |Scalene: a high-performance, high-precision CPU, GPU, and memory profiler for Python with AI-powered optimization proposals|[Github](https://github.com/plasma-umass/scalene) </br>![GitHub Repo stars](https://img.shields.io/github/stars/plasma-umass/scalene?style=social)|Free|
 | Kodus | Open Source Code Review Agent | [GitHub](https://github.com/kodustech/kodus-ai/) <img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/kodustech/kodus-ai?style=social"> | Free/Paid|
 | Kagan | AI-powered Kanban TUI for autonomous development workflows. Integrates with Claude Code and OpenCode for ticket-driven AI coding with git worktree isolation and MCP server support. | [GitHub](https://github.com/aorumbayev/kagan) ![GitHub Repo stars](https://img.shields.io/github/stars/aorumbayev/kagan?style=social) | Free |
+| Steel Browser | Open-source browser sandbox and automation infrastructure for AI agents and apps with session-backed workflows, screenshots, PDFs, proxies, and anti-bot tooling. | [Github](https://github.com/steel-dev/steel-browser) ![GitHub Repo stars](https://img.shields.io/github/stars/steel-dev/steel-browser?style=social) | Free |
 
 ### AI Image Creation
 | Name | Description | Links | Fees | 


### PR DESCRIPTION
This adds Steel Browser to the AI Coding section.

Steel Browser is open-source browser sandbox and automation infrastructure for AI agents and apps. It fits here because it gives coding and agent workflows a real browser path with session-backed automation, screenshots, PDFs, proxies, and anti-bot tooling.

Links:
- Repo: https://github.com/steel-dev/steel-browser
- CLI: https://github.com/steel-dev/cli
- Docs: https://docs.steel.dev/llms-full.txt
- Blog: https://steel.dev/blog/introducing-steel-cli-v0-2-0-browser-automation-built-for-agents

Example use case: use an AI coding workflow to automate a JS-heavy dashboard, extract content, and save screenshot and PDF artifacts.