### PR TITLE
Add Signbee - Document signing for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | skills.sh | Community-driven skills registry and marketplace for AI assistants, providing a curated collection of reusable skills for various AI platforms including Claude Code, OpenAI GPT, and other LLM assistants, with download usage statistics and trending popularity rankings for all skills | [Website](https://skills.sh/) | Free/Paid |
 | JimLiu/baoyu-skills | Community skills repository for Claude Code, providing practical Chinese-language and region-specific skills including Weibo posting functionality | [Github](https://github.com/JimLiu/baoyu-skills) ![GitHub Repo stars](https://img.shields.io/github/stars/JimLiu/baoyu-skills?style=social) | Free |
 | ClawHub | A fast skill registry for AI agents, with vector search capabilities. Provides a centralized platform for managing and discovering agent skills. | [URL](https://clawhub.ai/) | Free/Paid |
+| Signbee | Document signing for AI agents. Send contracts for e-signature via MCP, Agent Skill, or direct API call with email OTP verification and SHA-256 signing certificates. | [Github](https://github.com/signbee/mcp) ![GitHub Repo stars](https://img.shields.io/github/stars/signbee/mcp?style=social), [Website](https://signb.ee) | Free/Paid |
 
 ### AI Image Creation
 | Name | Description | Links | Fees | 


### PR DESCRIPTION
Adds Signbee to the Agent Skills section.

Signbee is a document signing API that lets AI agents send contracts for e-signature via MCP, Agent Skill, or direct API call.

- **npm**: https://www.npmjs.com/package/signbee-mcp
- **GitHub**: https://github.com/signbee/mcp
- **Website**: https://signb.ee