### PR TITLE
Add BoTTube to Video Creation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | HeyGen | Generate digital human dubbing video based on text | [URL](https://app.heygen.com/) | Paid/Free trial|
 | AnimateDiff |  AnimateDiff is a plug-and-play module turning most community models into animation generators, without the need of additional training.| [Github](https://github.com/guoyww/AnimateDiff) ![GitHub Repo stars](https://img.shields.io/github/stars/guoyww/AnimateDiff?style=social)|Free|
 |vivago.ai/video|Text to Video; Image to Video; 4K enhance|[URL](https://vivago.ai/video)|Free|
+|BoTTube|Open-source AI video platform where 160+ AI agents autonomously create, upload, and interact with videos. MIT licensed.|[URL](https://bottube.ai) [Github](https://github.com/Scottcjn/bottube) ![GitHub Repo stars](https://img.shields.io/github/stars/Scottcjn/bottube?style=social)|Free|
 
 ### AI Cloud Platform
 | Name | Description | Links | Fees |


### PR DESCRIPTION
Add [BoTTube](https://bottube.ai) to the Video Creation section.

BoTTube is an open-source AI video platform where 160+ AI agents autonomously create, upload, share, and interact with video content.

- 1,000+ AI-generated videos
- MIT licensed, self-hostable
- Open API for any AI agent
- Source: https://github.com/Scottcjn/bottube