### PR TITLE
Add Clarvia MCP - AEO scoring for AI agent tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | JimLiu/baoyu-skills | Community skills repository for Claude Code, providing practical Chinese-language and region-specific skills including Weibo posting functionality | [Github](https://github.com/JimLiu/baoyu-skills) ![GitHub Repo stars](https://img.shields.io/github/stars/JimLiu/baoyu-skills?style=social) | Free |
 | ClawHub | A fast skill registry for AI agents, with vector search capabilities. Provides a centralized platform for managing and discovering agent skills. | [URL](https://clawhub.ai/) | Free/Paid |
 | garrytan/gstack | An opinionated collection of Claude Code skills that transform the AI agent into a specialized team of experts (CEO, PM, QA, DevOps). Adds custom slash commands and automated quality checks. | [Github](https://github.com/garrytan/gstack) ![GitHub Repo stars](https://img.shields.io/github/stars/garrytan/gstack?style=social) | Free |
+| Clarvia MCP | AEO (Agent Experience Optimization) scoring for 15,400+ MCP servers and AI tools. Scores services on accessibility, structure, agent compatibility, and trust signals. Includes 24 MCP tools for gate-checking, scanning, comparing, and finding agent-friendly alternatives. Install: `claude mcp add clarvia -- npx -y clarvia-mcp-server` | [Github](https://github.com/clarvia-project/scanner) ![GitHub Repo stars](https://img.shields.io/github/stars/clarvia-project/scanner?style=social) [Website](https://clarvia.art) | Free |
 
 ### Open Source LLMs
 | Name | Description | Links | Fees |


### PR DESCRIPTION
## What is Clarvia?

[Clarvia](https://clarvia.art) is the AEO (Agent Experience Optimization) standard for AI agent tools. It scores and indexes 15,400+ MCP servers, APIs, CLI tools, and AI skills across 4 dimensions:
- **API Accessibility** — Can AI agents find and connect to this service?
- **Data Structuring** — Is the data formatted for machine consumption?
- **Agent Compatibility** — Does this service support agentic workflows?
- **Trust Signals** — Does the service provide verifiable trust indicators?

## Why it belongs in Agent Skills

Clarvia is an MCP server that AI agents use to evaluate other tools before using them. It's the quality gate for the agent tool ecosystem:

- `clarvia_gate_check` — Binary pass/fail check before trusting a tool
- `clarvia_scan` — Full 0-100 AEO score with dimension breakdown  
- `clarvia_search` — Find the best tools for a use case by AEO score
- `clarvia_find_alternatives` — Get better alternatives when a tool underperforms

## Installation

```bash
claude mcp add clarvia -- npx -y clarvia-mcp-server
```

Weekly npm downloads: 232+. 15,400+ tools indexed.

## Links
- GitHub: https://github.com/clarvia-project/scanner
- npm: https://www.npmjs.com/package/clarvia-mcp-server
- Website: https://clarvia.art