### PR TITLE
Add CodeCosts — AI coding tools pricing comparison

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -169,6 +169,7 @@
 | Termux | Android终端模拟器和Linux环境应用，可直接在移动设备上运行编码工具、AI模型和各类开发环境，内置SSH客户端支持登录远程主机。 | [Github](https://github.com/termux/termux-app) ![GitHub Repo stars](https://img.shields.io/github/stars/termux/termux-app?style=social) | 免费 |
 | AI-Codereview-Gitlab | 基于大模型(DeepSeek, OpenAI等)的 GitLab 自动代码审查工具；支持钉钉/企业微信/飞书推送消息和生成日报；支持Docker部署；可视化 Dashboard。 | [Github](https://github.com/sunmh207/AI-Codereview-Gitlab) ![GitHub Repo stars](https://img.shields.io/github/stars/sunmh207/AI-Codereview-Gitlab?style=social) | 免费 |
 | Lark CLI | 飞书官方命令行工具，帮助开发者快速开发和管理飞书应用 | [Github](https://github.com/larksuite/cli) ![GitHub Repo stars](https://img.shields.io/github/stars/larksuite/cli?style=social) | 免费 |
+| CodeCosts | AI编程工具价格对比网站（Cursor、GitHub Copilot、Windsurf等），提供免费公开API | [URL](https://codecosts.pages.dev), [API](https://codecosts-api.pingbase-api.workers.dev) | 免费 |
 
 
 ### AI图像创作

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | Termux | Android terminal emulator and Linux environment app that allows you to run coding tools, AI models and development environments directly on your mobile device, with built-in SSH client support for logging into remote hosts. | [Github](https://github.com/termux/termux-app) ![GitHub Repo stars](https://img.shields.io/github/stars/termux/termux-app?style=social) | Free |
 | AI-Codereview-Gitlab | GitLab automatic code review tool based on LLMs (DeepSeek, OpenAI, etc.). Supports DingTalk/WeCom/Feishu notifications and daily reports generation. Docker deployment supported with visual Dashboard. | [Github](https://github.com/sunmh207/AI-Codereview-Gitlab) ![GitHub Repo stars](https://img.shields.io/github/stars/sunmh207/AI-Codereview-Gitlab?style=social) | Free |
 | Lark CLI | Feishu (Lark) official command-line interface tool, helping developers quickly develop and manage Feishu applications | [Github](https://github.com/larksuite/cli) ![GitHub Repo stars](https://img.shields.io/github/stars/larksuite/cli?style=social) | Free |
+| CodeCosts | Pricing comparison site for AI coding tools (Cursor, GitHub Copilot, Windsurf, etc.) with a free public API | [URL](https://codecosts.pages.dev), [API](https://codecosts-api.pingbase-api.workers.dev) | Free |
 
 ### AI Image Creation
 | Name | Description | Links | Fees |


### PR DESCRIPTION
## Summary

- Adds [CodeCosts](https://codecosts.pages.dev) to the **AI Coding** section in both the English and Chinese READMEs
- CodeCosts is a pricing comparison site for AI coding tools (Cursor, GitHub Copilot, Windsurf, etc.) with a free public API
- Entry follows existing table format

## Links

- Site: https://codecosts.pages.dev
- API: https://codecosts-api.pingbase-api.workers.dev