### PR TITLE
Add toprank to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | JimLiu/baoyu-skills | Community skills repository for Claude Code, providing practical Chinese-language and region-specific skills including Weibo posting functionality | [Github](https://github.com/JimLiu/baoyu-skills) ![GitHub Repo stars](https://img.shields.io/github/stars/JimLiu/baoyu-skills?style=social) | Free |
 | ClawHub | A fast skill registry for AI agents, with vector search capabilities. Provides a centralized platform for managing and discovering agent skills. | [URL](https://clawhub.ai/) | Free/Paid |
 | garrytan/gstack | An opinionated collection of Claude Code skills that transform the AI agent into a specialized team of experts (CEO, PM, QA, DevOps). Adds custom slash commands and automated quality checks. | [Github](https://github.com/garrytan/gstack) ![GitHub Repo stars](https://img.shields.io/github/stars/garrytan/gstack?style=social) | Free |
+| nowork-studio/toprank | Open-source (MIT) Claude Code plugin with 9 SEO and Google Ads skills. Connects Google Search Console, PageSpeed Insights, and the Google Ads API to audit traffic, rewrite meta tags, generate JSON-LD schema markup, and ship fixes to WordPress/Strapi/Contentful/Ghost. | [Github](https://github.com/nowork-studio/toprank) ![GitHub Repo stars](https://img.shields.io/github/stars/nowork-studio/toprank?style=social) | Free |
 
 ### Office Collaboration CLI/MCP
 | Name | Description | Links | Fees |


### PR DESCRIPTION
Adds **toprank** to the Agent Skills section.

toprank is an open-source (MIT) Claude Code plugin providing 9 SEO and Google Ads skills. It connects Google Search Console, PageSpeed Insights, and the Google Ads API to audit traffic and wasted ad spend, rewrites meta tags, generates JSON-LD schema markup, and ships fixes to WordPress/Strapi/Contentful/Ghost.

- Source: https://github.com/nowork-studio/toprank
- License: MIT (Free)
- 100+ stars, actively maintained