### PR TITLE
Add BulkPublish MCP Server to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | JimLiu/baoyu-skills | Community skills repository for Claude Code, providing practical Chinese-language and region-specific skills including Weibo posting functionality | [Github](https://github.com/JimLiu/baoyu-skills) ![GitHub Repo stars](https://img.shields.io/github/stars/JimLiu/baoyu-skills?style=social) | Free |
 | ClawHub | A fast skill registry for AI agents, with vector search capabilities. Provides a centralized platform for managing and discovering agent skills. | [URL](https://clawhub.ai/) | Free/Paid |
 | garrytan/gstack | An opinionated collection of Claude Code skills that transform the AI agent into a specialized team of experts (CEO, PM, QA, DevOps). Adds custom slash commands and automated quality checks. | [Github](https://github.com/garrytan/gstack) ![GitHub Repo stars](https://img.shields.io/github/stars/garrytan/gstack?style=social) | Free |
+| BulkPublish MCP Server | Social media MCP server with 29 tools for 11 platforms. AI agents can create posts, schedule content, upload media, and track analytics via MCP. Also provides REST API, Python & Node.js SDKs. | [Github](https://github.com/azeemkafridi/bulkpublish-api) ![GitHub Repo stars](https://img.shields.io/github/stars/azeemkafridi/bulkpublish-api?style=social), [npm](https://www.npmjs.com/package/@bulkpublish/mcp-server) | Free/Paid |
 
 ### Office Collaboration CLI/MCP
 | Name | Description | Links | Fees |


### PR DESCRIPTION
## What is BulkPublish?

[BulkPublish](https://github.com/azeemkafridi/bulkpublish-api) is a social media API covering 11 platforms (Facebook, Instagram, X/Twitter, LinkedIn, TikTok, YouTube, Pinterest, Threads, Bluesky, Mastodon, Tumblr).

It is AI-native — the MCP server exposes 29 tools that let AI agents create posts, schedule content, upload media, and track analytics. Also available as a REST API with Python & Node.js SDKs.

- **MCP Server**: https://github.com/azeemkafridi/bulkpublish-api/tree/main/mcp-server
- **npm**: `@bulkpublish/mcp-server`
- **API**: https://app.bulkpublish.com/api

Added to the **Agent Skills** section in the existing table format.