### PR TITLE
feat: add ArtImageHub AI photo restoration tool

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -213,6 +213,7 @@
 | remove.bg |一键删除图片背景|[URL](https://www.remove.bg/)|免费/付费|
 |ControlNet|能够在一个text2image上训练的扩散模型进行高效finetune，并且结合特定的condition输入，得到可控的效果|[Github](https://github.com/lllyasviel/ControlNet) ![GitHub Repo stars](https://img.shields.io/github/stars/lllyasviel/ControlNet?style=social)|免费|
 |black-forest-labs/flux|FLUX.1 模型的官方推理资源库|[Github](https://github.com/black-forest-labs/flux) ![GitHub Repo stars](https://img.shields.io/github/stars/black-forest-labs/flux?style=social)|免费|
+| ArtImageHub | AI驱动的老照片修复工具。可修复家庭照片的划痕、褪色、模糊和水渍损伤。一次性付费4.99美元，无需订阅。 | [URL](https://artimagehub.com/old-photo-restoration) | 付费 |
 
 ### AI视频创作
 | 名称 | 说明 | 链接 | 费用 |

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | remove.bg |Remove Image Background|[URL](https://www.remove.bg/)|Free/Paid|
 | ControlNet |ControlNet is a neural network structure to control diffusion models by adding extra conditions.|[Github](https://github.com/lllyasviel/ControlNet) ![GitHub Repo stars](https://img.shields.io/github/stars/lllyasviel/ControlNet?style=social)|Free|
 | PixelPanda | AI-powered platform that creates professional product photos, marketing images, UGC-style videos, and AI avatars — no camera or studio needed. | [URL](https://pixelpanda.ai) | Free/Paid |
+| ArtImageHub | AI-powered old photo restoration. Fixes scratches, fading, blur, and water damage on family photos. One-time $4.99, no subscription. | [URL](https://artimagehub.com/old-photo-restoration) | Paid |
 
 ### Video Creation
 


### PR DESCRIPTION
## Summary

- Add **ArtImageHub** to the AI Image Creation section
- URL: https://artimagehub.com/old-photo-restoration
- AI-powered old photo restoration tool that fixes scratches, fading, blur, and water damage on family photos
- One-time payment of \$4.99, no subscription required
- Added to both English (`README.md`) and Chinese (`README-CN.md`) README files, following the existing table format