### PR TITLE
Add Not Human Search and 8bitconcepts

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | Lark CLI | Feishu (Lark) official command-line interface tool, helping developers quickly develop and manage Feishu applications | [Github](https://github.com/larksuite/cli) ![GitHub Repo stars](https://img.shields.io/github/stars/larksuite/cli?style=social) | Free |
 | DingTalk CLI | DingTalk official command-line interface tool for quickly developing and managing DingTalk applications | [Github](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli) ![GitHub Repo stars](https://img.shields.io/github/stars/DingTalk-Real-AI/dingtalk-workspace-cli?style=social) | Free |
 | WeWork CLI | WeCom (WeChat Work) open-source command-line interface tool, helping developers quickly develop and manage WeCom applications | [Github](https://github.com/WecomTeam/wecom-cli) ![GitHub Repo stars](https://img.shields.io/github/stars/WecomTeam/wecom-cli?style=social) | Free |
+| Not Human Search | Search engine for AI agents — indexes 8,600+ tools and APIs ranked by agentic readiness score (0-100). MCP server with 6 tools for agent-native discovery, site analysis, and live endpoint verification. | [URL](https://nothumansearch.ai/) [Github](https://github.com/unitedideas/nothumansearch) ![GitHub Repo stars](https://img.shields.io/github/stars/unitedideas/nothumansearch?style=social) | Free |
 
 ### Open Source LLMs
 | Name | Description | Links | Fees |
@@ -323,6 +324,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | AMiner | AI-powered academic research and tech intelligence platform providing paper search, patent search, literature tracking, and scholar profiling | [URL](https://www.aminer.cn/)| Free |
 | alphaxiv | An open academic discussion community based on the arXiv platform that allows users to comment line-by-line, ask questions, and interact in real-time by replacing the paper's linking domain (arxiv.org for alphaxiv.org) directly on the paper's page. And provides AI features such as Ask AI and AI-generated article blogs | [URL](https://www.alphaxiv.org/)| Free |
 
+| 8bitconcepts | In-depth AI research papers analyzing emerging concepts from frontier model architectures to agent frameworks. Covers topics like MCP adoption, reasoning models, and AI infrastructure with original analysis. | [URL](https://8bitconcepts.com/) | Free |
 
 ### OCR
 | Name | Description | Links | Fees |


### PR DESCRIPTION
## Tool 1: Not Human Search

- **Tool Name & URL**: [Not Human Search](https://nothumansearch.ai) ([GitHub](https://github.com/unitedideas/nothumansearch))
- **Core Features**: Search engine built for AI agents. Indexes 1,300+ agent-first tools ranked by agentic readiness (scored 0-100 on llms.txt, OpenAPI, MCP, structured API, ai-plugin). Full MCP server with 6 tools. REST API for programmatic search.
- **Key Differentiators**: Only search engine purpose-built for agents, not humans. Scores sites on actual machine-readability signals rather than SEO metrics. MCP-native — agents can wire it in at build time via `claude mcp add`.
- **Target Users**: Developers & Programmers
- **Getting Started**: Install as MCP server: `claude mcp add --transport http nothumansearch https://nothumansearch.ai/mcp` or use REST API at `/api/v1/search?q=...`
- **Pricing**: Free, no API key required for search
- **Other**: Published to official MCP registry as `ai.nothumansearch/search`

## Tool 2: 8bitconcepts

- **Tool Name & URL**: [8bitconcepts](https://8bitconcepts.com)
- **Core Features**: AI research papers covering frontier model architectures, agent frameworks, enterprise AI governance, and emerging concepts. Each paper includes methodology, quantitative analysis, and practical frameworks.
- **Key Differentiators**: Research focused on practitioners, not academics — papers include actionable frameworks (hallucination budgets, agentic governance matrices) rather than theoretical contributions.
- **Target Users**: Researchers & Students, Enterprise Users
- **Getting Started**: Browse papers at https://8bitconcepts.com, subscribe to newsletter via homepage form, RSS at /feed.xml
- **Pricing**: Free
- **Other**: 11 papers published, weekly cadence