### PR TITLE
Add Not Human Search and AI Dev Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 |OpenRouter| A unified API gateway for 400+ AI models (OpenAI, Anthropic, Google, Mistral, etc.). Zero markup pricing, 5% commission on inference traffic, supports smart routing/failover |[URL](https://openrouter.ai/)| Free/Paid |
 | OmniRoute | Self-hostable AI gateway with 4-tier automatic fallback routing across 36+ providers. OpenAI-compatible API with quota tracking and zero-cost fallback to free tiers. | [GitHub](https://github.com/diegosouzapw/OmniRoute) <br> ![GitHub Repo stars](https://img.shields.io/github/stars/diegosouzapw/OmniRoute?style=social) | Free |
 | Morphik.ai | Open source AI-driven search engine for private documents | [URL](https://morphik.ai) [Github](https://github.com/morphik-org/morphik-core) ![GitHub Repo stars](https://img.shields.io/github/stars/morphik-org/morphik-core?style=social)| Free |
+| Not Human Search | AI tool discovery engine with agentic scoring. Indexes 8,600+ AI tools and MCP servers. REST API and MCP server for programmatic access. | [URL](https://nothumansearch.ai/) | Free |
+| AI Dev Jobs | AI/ML-focused job board aggregating 5,600+ jobs from 300+ companies. REST API and MCP server for programmatic job search. | [URL](https://aidevboard.com/) | Free |
 
 ### AI Coding
 | Name | Description | Links | Fees |


### PR DESCRIPTION
## Tool 1: Not Human Search

- **Tool Name & URL**: [Not Human Search](https://nothumansearch.ai)
- **Core Features**: Search engine for AI agent tools and MCP servers. Indexes 1,750+ sites ranked by agentic readiness score (0-100). Provides REST API and MCP server for programmatic access to the full index.
- **Key Differentiators**: Only search engine purpose-built for AI agents. Scores every indexed site on 7 signals (llms.txt, OpenAPI, MCP, API, ai-plugin, robots.txt, schema.org). Available as an MCP server that agents can wire in at build time.
- **Target Users**: Developers & Programmers
- **Getting Started**: Visit https://nothumansearch.ai or connect via MCP: `claude mcp add --transport http nothumansearch https://nothumansearch.ai/mcp`
- **Pricing**: Free
- **Other**: Open REST API at /api/v1/search, OpenAPI spec at /openapi.yaml

## Tool 2: AI Dev Jobs

- **Tool Name & URL**: [AI Dev Jobs](https://aidevboard.com)
- **Core Features**: AI/ML-focused job board aggregating 5,500+ curated roles from 289 companies. REST API and MCP server for programmatic job search. Filters by tag, salary, location, workplace type.
- **Key Differentiators**: Only job board with a real REST API and MCP server for AI agents. Every listing is an AI/ML role — no generalist noise. Auto-synced daily from 315 ATS sources.
- **Target Users**: Developers & Programmers
- **Getting Started**: Browse at https://aidevboard.com or API docs at https://aidevboard.com/docs
- **Pricing**: Free for job seekers. Free company profiles.
- **Other**: RSS feed at /feed.xml, OpenAPI spec at /openapi.yaml