### PR TITLE
Add HAQQ Legal AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 |OpenRouter| A unified API gateway for 400+ AI models (OpenAI, Anthropic, Google, Mistral, etc.). Zero markup pricing, 5% commission on inference traffic, supports smart routing/failover |[URL](https://openrouter.ai/)| Free/Paid |
 | OmniRoute | Self-hostable AI gateway with 4-tier automatic fallback routing across 36+ providers. OpenAI-compatible API with quota tracking and zero-cost fallback to free tiers. | [GitHub](https://github.com/diegosouzapw/OmniRoute) <br> ![GitHub Repo stars](https://img.shields.io/github/stars/diegosouzapw/OmniRoute?style=social) | Free |
 | Morphik.ai | Open source AI-driven search engine for private documents | [URL](https://morphik.ai) [Github](https://github.com/morphik-org/morphik-core) ![GitHub Repo stars](https://img.shields.io/github/stars/morphik-org/morphik-core?style=social)| Free |
+| HAQQ Legal AI | Bilingual Arabic/English legal AI for MENA law firms: legal research, contract review, and case law search across Lebanese, GCC, and Egyptian jurisdictions. | [URL](https://haqq.ai) | Free/Paid |
 
 ### AI Coding
 | Name | Description | Links | Fees |


### PR DESCRIPTION
Adds HAQQ Legal AI to GPT LLMs Applications — a bilingual (Arabic/English) legal AI platform for MENA law firms covering legal research, contract review, and case law search across Lebanese, GCC, and Egyptian jurisdictions.

- Site: https://haqq.ai
- Format matches the existing 4-column table (Name / Description / Links / Fees).