### PR TITLE
Add igly.ai to AI Image Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | remove.bg |Remove Image Background|[URL](https://www.remove.bg/)|Free/Paid|
 | ControlNet |ControlNet is a neural network structure to control diffusion models by adding extra conditions.|[Github](https://github.com/lllyasviel/ControlNet) ![GitHub Repo stars](https://img.shields.io/github/stars/lllyasviel/ControlNet?style=social)|Free|
 | PixelPanda | AI-powered platform that creates professional product photos, marketing images, UGC-style videos, and AI avatars — no camera or studio needed. | [URL](https://pixelpanda.ai) | Free/Paid |
+| igly.ai | Free AI image editor with 12+ tools for e-commerce sellers, including background removal, object inpainting, image upscale, virtual try-on, and more. Browser-based, no signup required. | [URL](https://igly.ai) | Free/Paid |
 
 ### Video Creation
 


### PR DESCRIPTION
## Proposed Addition

**igly.ai** — https://igly.ai

A free AI image editor with 12+ tools for e-commerce sellers. Browser-based, no signup required for basic tools.

**Why include it?**
- Fits AI Image Creation category (similar to clipdrop, remove.bg, PixelPanda)
- Free tier available
- Open source: https://github.com/Whatscheap/media-agent

Added in the AI Image Creation table following existing format.