### PR TITLE
Add Creative AI News to News Information section

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | Name | Description | Links | Fees |
 | --- | --- | --- | --- |
 | World Monitor | AI-powered real-time global intelligence dashboard with 435+ curated feeds, geopolitical monitoring, infrastructure tracking, AI summaries, 21 languages support, local AI runtime and cross-platform native desktop apps | [Github](https://github.com/koala73/worldmonitor) ![GitHub Repo stars](https://img.shields.io/github/stars/koala73/worldmonitor?style=social), [Official Site](https://worldmonitor.app) | Free |
+| Creative AI News | Weekly AI tools and workflows for every working creator: image, video, audio, 3D, and code. | [Official Site](https://www.creativeainews.com) | Free |
 
 ### Writing
 | Name | Description | Links | Fees |


### PR DESCRIPTION
Adding [Creative AI News](https://www.creativeainews.com), a weekly newsletter covering AI tools and workflows for working creators across image, video, audio, 3D, and code.

Quick context:
- 411 published articles, weekly cadence
- Pillar guides covering AI Video, AI Image, ComfyUI, AI Coding, AI Music, and Open-Source AI
- Editorial focus on what ships for creators, not benchmark sheets

Added one row to the News Information section, matching the existing table format. Free to access; no Github repo so the Links column only includes the Official Site.