### PR TITLE
Add Instafill.ai under Office Collaboration CLI/MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | Lark CLI | Feishu (Lark) official command-line interface tool, helping developers quickly develop and manage Feishu applications | [Github](https://github.com/larksuite/cli) ![GitHub Repo stars](https://img.shields.io/github/stars/larksuite/cli?style=social) | Free |
 | DingTalk CLI | DingTalk official command-line interface tool for quickly developing and managing DingTalk applications | [Github](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli) ![GitHub Repo stars](https://img.shields.io/github/stars/DingTalk-Real-AI/dingtalk-workspace-cli?style=social) | Free |
 | WeWork CLI | WeCom (WeChat Work) open-source command-line interface tool, helping developers quickly develop and manage WeCom applications | [Github](https://github.com/WecomTeam/wecom-cli) ![GitHub Repo stars](https://img.shields.io/github/stars/WecomTeam/wecom-cli?style=social) | Free |
+| Instafill.ai | AI-powered PDF form filler MCP server. Auto-completes any PDF form by extracting fields and filling them from saved profiles, uploaded files, or supplied data. | [Website](https://instafill.ai) | Free/Paid |
 
 ### Open Source LLMs
 | Name | Description | Links | Fees |


### PR DESCRIPTION
Adding [Instafill.ai](https://instafill.ai) under **Office Collaboration CLI/MCP**.

Instafill.ai is an AI-powered PDF form filler that ships an MCP server. It auto-completes any PDF form by extracting fields and filling them from saved profiles, uploaded files, or supplied data — exposing form-completion as a tool to AI agents (Claude, Cursor, etc.). Fits the section alongside other office/MCP integrations.