### PR TITLE
feat: add BudgetForge — budget enforcement for LLM pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 |LLM Stats|LLM Stats, the most comprehensive LLM leaderboard, benchmarks and compares API models using daily‑updated, open‑source community data on capability, price, speed, and context length.|[URL](https://llm-stats.com/)|Free|
 |Price Per Token|Compare LLM API pricing across 200+ models from OpenAI, Anthropic, Google, and more. Includes token counters, cost calculators, and benchmark comparisons.|[URL](https://pricepertoken.com/)|Free|
 |BenchGecko|The data layer of the AI economy. AI model benchmark leaderboard with cross-provider pricing comparison across hundreds of providers. Tracks thousands of models across 128 benchmarks, AI economy indicators, agent leaderboard, and MCP server directory. Free API.|[URL](https://benchgecko.ai/)|Free|
+|BudgetForge|Hard spending limits for LLM and agent pipelines — per-project token budgets, real-time cost tracking, multi-provider enforcement (OpenAI, Anthropic, Mistral, Groq). Python SDK and LangChain integration.|[URL](https://llmbudget.maxiaworld.app) \| [PyPI](https://pypi.org/project/budgetforge/)|Free/Paid|
 
 ### GPT LLMs Applications
 | Name | Description | Links | Fees |


### PR DESCRIPTION
## What

Adds **BudgetForge** to the LLM Leaderboard section (cost/pricing tools).

## Entry added

| BudgetForge | Hard spending limits for LLM and agent pipelines — per-project token budgets, real-time cost tracking, multi-provider enforcement (OpenAI, Anthropic, Mistral, Groq). Python SDK and LangChain integration. | [URL](https://llmbudget.maxiaworld.app) \| [PyPI](https://pypi.org/project/budgetforge/) | Free/Paid |

## Why it fits

BudgetForge enforces hard spending caps on LLM API calls. It belongs alongside cost/pricing tools like Price Per Token and BenchGecko. Placed in alphabetical order after BenchGecko.

- PyPI: https://pypi.org/project/budgetforge/
- Supports: OpenAI, Anthropic, Mistral, Groq