### PR TITLE
Add AdDogs to AI Image Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | remove.bg |Remove Image Background|[URL](https://www.remove.bg/)|Free/Paid|
 | ControlNet |ControlNet is a neural network structure to control diffusion models by adding extra conditions.|[Github](https://github.com/lllyasviel/ControlNet) ![GitHub Repo stars](https://img.shields.io/github/stars/lllyasviel/ControlNet?style=social)|Free|
 | PixelPanda | AI-powered platform that creates professional product photos, marketing images, UGC-style videos, and AI avatars — no camera or studio needed. | [URL](https://pixelpanda.ai) | Free/Paid |
+| AdDogs | AI ad creative generator. Clones any winning ad design, swaps in your product photo, and applies your brand colors and logo in seconds. Exports in 14 aspect ratios for Instagram, TikTok, Facebook, and Google. | [URL](https://www.addogs.ai) | Free/Paid |
 
 ### Video Creation
 


### PR DESCRIPTION
Adds [AdDogs](https://www.addogs.ai) to the AI Image Creation table.

**What it is:** AI ad creative generator. Pick any winning ad design, upload your product photo, and the AI recreates the ad with your product — preserving the original layout, style, and composition. Brand colors and logo are extracted automatically.

**Why it fits this section:** Like PixelPanda and Nero AI in this section, AdDogs takes a product photo and generates marketing visuals; specifically, it generates ad creatives across 14 aspect ratios for Instagram, TikTok, Facebook, and Google.

**Pricing:** Freemium. Free tier with 5 credits, paid plans from $12/mo. Marked as Free/Paid to match the section's convention.

Happy to revise wording, placement, or column values if anything needs adjusting. Thanks for maintaining this list.