### PR TITLE
Add Agentprobe — agentic commerce readiness scorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 |MemPalace|Open-source AI memory system that stores full conversations and project data locally without cloud dependencies. Organizes memories into a hierarchical "palace" structure, achieves 96.6% recall on LongMemEval benchmarks (highest scoring), supports MCP integration and works offline with local LLMs.|[Github](https://github.com/milla-jovovich/mempalace) ![GitHub Repo stars](https://img.shields.io/github/stars/milla-jovovich/mempalace?style=social)|Free|
 | codesight | CLI token optimizer and AI context generator with built-in MCP server. Scans codebases to extract routes, schema, components, and dependencies, reducing AI context tokens by 9x–13x. Profiles for Claude Code, Cursor, Copilot, Codex, and Windsurf. Zero runtime dependencies. | [Github](https://github.com/Houseofmvps/codesight) ![GitHub Repo stars](https://img.shields.io/github/stars/Houseofmvps/codesight?style=social) | Free |
 
+| Agentprobe | Free agentic commerce readiness scorer. Probes any seller URL across 13 signals (llms.txt, OpenAPI spec, MCP endpoint, catalog/quote/checkout APIs, payment rails, fulfillment proof) and returns a 0–110 score with CERTIFIED badge. Tells AI agents which storefronts they can actually transact with. | [URL](https://agentprobe.fly.dev/) | Free |
+
 ### Agent Skills
 | Name | Description | Links | Fees |
 | --- | --- | --- | --- |


### PR DESCRIPTION
## What this adds

**Agentprobe** — free agentic commerce readiness scorer that tells AI agents which storefronts they can actually discover, quote, and transact with.

## How it works

Probes any seller URL across 13 signals:
- llms.txt, OpenAPI spec, ai-plugin.json, MCP endpoint
- Machine-readable catalog, quote endpoint, checkout handoff
- Payment rail declarations, unsupported-rail handling
- Refund/contact metadata, fulfillment proof, no-fake-claims check

Returns a 0–110 score with grade tiers: NOT_READY / PARTIAL / AGENT_READY / CERTIFIED.

## Why it belongs in AI Agent

As AI shopping agents proliferate, the question "can this agent actually buy from this site?" needs an answer. Agentprobe is the tool that answers it — both for developers building agents and for operators making their sites agent-ready.

- Tool: https://agentprobe.fly.dev/
- Free, no signup required
- MCP server available at /mcp for agent-native usage