### PR TITLE
Add 13F Insight to AI Finance & Quant Investment section

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 |VNPy|A comprehensive open-source quantitative trading framework in Python, supports strategy backtesting, live trading across multiple exchanges, and integrates AI/LLM capabilities for financial market analysis and strategy development. Widely used by quant traders in China.|[Github](https://github.com/vnpy/vnpy) ![GitHub Repo stars](https://img.shields.io/github/stars/vnpy/vnpy?style=social)|Free|
 |TimesFM|Google Research's open-source pretrained time-series foundation model for time-series forecasting. Supports long context (16k) and long-horizon forecasting up to 1k steps, which is widely used for financial and quantitative investment predictions.|[Github](https://github.com/google-research/timesfm) ![GitHub Repo stars](https://img.shields.io/github/stars/google-research/timesfm?style=social)|Free|
 | Dexter | Autonomous financial research agent designed to perform deep analysis by thinking, planning, and learning through iteration. Specialized for the financial domain. [Intro](docs/dexter/README.md) | [Github](https://github.com/virattt/dexter) ![GitHub Repo stars](https://img.shields.io/github/stars/virattt/dexter?style=social) | Free |
+| 13F Insight | AI-powered platform to track institutional investor 13F holdings, hedge fund portfolios, and SEC filings. Ask an AI agent about any filer, stock, or insider — with real citations from SEC data. | [URL](https://13finsight.com) | Free/Paid |
 
 ### AI Image Creation
 | Name | Description | Links | Fees |


### PR DESCRIPTION
## Add 13F Insight to AI Finance & Quant Investment section

**13F Insight** is an AI-powered platform for tracking institutional investor 13F holdings and SEC filings.

- **What it does**: Lets users ask an AI agent questions about any hedge fund filer, stock holder, or insider — with citations sourced directly from real SEC filings (13F, Form 4, 13D/G)
- **Why it fits this section**: Uses LLM-based AI agents over real SEC data; targeted at quantitative researchers, fundamental investors, and institutional data consumers
- **Fees**: Free tier (2 AI agent questions without signup, 5/day with account); paid plans for full access
- **URL**: https://13finsight.com
- **Data coverage**: 30,000+ institutional filers, 5M+ SEC filings, data since 1994