### PR TITLE
Add AI Cost Calculator to LLM Leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 |LiveCodeBench|LiveCodeBench is a holistic and contamination-free evaluation benchmark of LLMs for code that continuously collects new problems over time. Particularly, LiveCodeBench also focuses on broader code-related capabilities, such as self-repair, code execution, and test output prediction, beyond mere code generation. |[URL](https://livecodebench.github.io/leaderboard.html)|Free|
 |LLM Stats|LLM Stats, the most comprehensive LLM leaderboard, benchmarks and compares API models using daily‑updated, open‑source community data on capability, price, speed, and context length.|[URL](https://llm-stats.com/)|Free|
 |Price Per Token|Compare LLM API pricing across 200+ models from OpenAI, Anthropic, Google, and more. Includes token counters, cost calculators, and benchmark comparisons.|[URL](https://pricepertoken.com/)|Free|
+|AI Cost Calculator|Compare pricing across 200+ LLM API models from OpenAI, Anthropic, Google, DeepSeek, and more. Includes token counters, cost estimates, and benchmark comparisons. Free, no signup.|[URL](https://model-calculator.com/)|Free|
 |BenchGecko|The data layer of the AI economy. AI model benchmark leaderboard with cross-provider pricing comparison across hundreds of providers. Tracks thousands of models across 128 benchmarks, AI economy indicators, agent leaderboard, and MCP server directory. Free API.|[URL](https://benchgecko.ai/)|Free|
 
 ### GPT LLMs Applications


### PR DESCRIPTION
Adds [AI Cost Calculator](https://model-calculator.com/) to the LLM Leaderboard section.\n\nFree tool to compare pricing across 200+ LLM models from OpenAI, Anthropic, Google, DeepSeek, and more. Includes token counters and cost estimates - no signup required.