### PR TITLE
Add Punch Needle Generator to AI Image Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | remove.bg |Remove Image Background|[URL](https://www.remove.bg/)|Free/Paid|
 | ControlNet |ControlNet is a neural network structure to control diffusion models by adding extra conditions.|[Github](https://github.com/lllyasviel/ControlNet) ![GitHub Repo stars](https://img.shields.io/github/stars/lllyasviel/ControlNet?style=social)|Free|
 | PixelPanda | AI-powered platform that creates professional product photos, marketing images, UGC-style videos, and AI avatars — no camera or studio needed. | [URL](https://pixelpanda.ai) | Free/Paid |
+| Punch Needle Generator | AI-powered punch needle embroidery pattern generator with color-coded yarn maps. Generates patterns from text prompts or image uploads, exports PDF/PNG/SVG. | [URL](https://www.punchneedle.co.il/en) | Free/Paid |
 
 ### Video Creation
 


### PR DESCRIPTION
Adds Punch Needle Generator under **AI Image Creation**.

- **Name:** Punch Needle Generator
- **URL:** https://www.punchneedle.co.il/en
- **Description:** AI-powered punch needle embroidery pattern generator with color-coded yarn maps. Generates patterns from text prompts or image uploads, exports PDF/PNG/SVG.
- **Pricing:** Free/Paid (free tier: 5 patterns/day)

I'm the maintainer of the tool. Single entry, follows the existing table format for the AI Image Creation section.