### PR TITLE
Add Anlora to AI Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | Screenpipe | Open-source 24/7 local screen + microphone recorder with OCR, audio transcription, and semantic search. Provides AI agents with long-term context of everything you've seen, said, or heard via MCP. Fully offline with Ollama or any local LLM. Cross-platform (macOS / Windows / Linux). | [Github](https://github.com/screenpipe/screenpipe) ![GitHub Repo stars](https://img.shields.io/github/stars/screenpipe/screenpipe?style=social) | Free |
 | CC Switch | Cross-platform desktop app to manage Claude Code, Codex, Gemini CLI, OpenCode, and OpenClaw. Features visual configuration for API providers, MCP servers, and skills with bidirectional sync. [Intro](docs/cc-switch/README.md) | [Github](https://github.com/farion1231/cc-switch) ![GitHub Repo stars](https://img.shields.io/github/stars/farion1231/cc-switch?style=social) | Free |
 | Multica | Open-source managed agents platform to integrate AI coding agents (Claude Code, Copilot, etc.) into dev teams as first-class teammates. Features task assignment, progress tracking, and reusable skills. [Intro](docs/multica/README.md) | [Github](https://github.com/multica-ai/multica) ![GitHub Repo stars](https://img.shields.io/github/stars/multica-ai/multica?style=social) | Free/Paid |
+| Anlora | Fully autonomous AI chatter for OnlyFans agencies — profiles each fan and runs every conversation end-to-end with no human in the loop. | [URL](https://meetanlora.com) | Paid |
 
 ### Agent Skills
 | Name | Description | Links | Fees |


### PR DESCRIPTION
Adds Anlora to the AI Agent section.

Anlora is a vertical autonomous agent for OnlyFans agencies: it profiles each fan and runs every conversation end-to-end with no human in the loop (distinct from assistant-style tools that only help a human chatter). Placed under "AI Agent" because it autonomously takes actions end-to-end rather than functioning as a general-purpose chatbot.

Submitted by the Anlora team.

- Row matches table schema: Name | Description | Links | Fees
- Fees: Paid
- https://meetanlora.com