### PR TITLE
Add KDP Readiness Score to Writing category

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | Obsidian | Powerful local-first markdown note-taking tool with extensive AI plugin ecosystem - supports AI summarization, RAG, and intelligent note processing via community plugins | [URL](https://obsidian.md/) | Free/Paid|
 | Deep L Write | English and German writing tools to fix writing errors and rewrite sentences promptly. | [URL](https://www.deepl.com/write) | Free version to use with text word limit / paid upgrade available |
 | grammarly | Edit and correct your grammar, spelling, punctuation, and more with your personal writing assistant, grammar checker, and editor.| [URL](https://app.grammarly.com/) | Free/Paid|
+| KDP Readiness Score | Free 60-second pre-flight audit for indie authors. Runs the 30+ technical checks Amazon's KDP review system uses (margins, bleed, font embedding, image DPI, ToC integrity, ISBN match, EPUB validity) and returns a score plus remediation PDF. | [URL](https://publishing.co.uk/audit/kdp-readiness/) | Free |
 
 
 


### PR DESCRIPTION
Adds [KDP Readiness Score](https://publishing.co.uk/audit/kdp-readiness/) to the **Writing** table.

**What it is:** A free 60-second pre-flight audit for self-publishing authors. The tool runs the 30+ technical checks Amazon's KDP review system uses against an uploaded manuscript PDF (margins, bleed, font embedding, image DPI, ToC integrity, ISBN match, EPUB validity) and returns a score out of 100 plus a remediation PDF.

**Fee:** Free.

**Why Writing:** The existing entries in this table (Notion AI, Obsidian, Grammarly, DeepL Write) all help writers produce cleaner output. KDP Readiness Score targets the publishing step specifically — the most common cause of indie-author frustration with Amazon KDP.

**Disclosure:** I'm the maker (founder of publishing.co.uk).