### PR TITLE
Add RemoveGlassesGlare to the AI Image Creation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | remove.bg |Remove Image Background|[URL](https://www.remove.bg/)|Free/Paid|
 | ControlNet |ControlNet is a neural network structure to control diffusion models by adding extra conditions.|[Github](https://github.com/lllyasviel/ControlNet) ![GitHub Repo stars](https://img.shields.io/github/stars/lllyasviel/ControlNet?style=social)|Free|
 | PixelPanda | AI-powered platform that creates professional product photos, marketing images, UGC-style videos, and AI avatars — no camera or studio needed. | [URL](https://pixelpanda.ai) | Free/Paid |
+| RemoveGlassesGlare | Remove glare from glasses in photos| [URL](https://removeglassesglare.com) | Paid |
 
 ### Video Creation
 


### PR DESCRIPTION
Add RemoveGlassesGlare, an AI based web app for removing reflections/glare from eyeglasses in photos to the AI Image Creation section.

Tool Name & URL: RemoveGlassesGlare (https://removeglassesglare.com)
Core Features: Removes glare from eyeglasses in photos in one click. 
Key Differentiators: Other tools mentioned do multiple things. This is the only tool in the list that only removes glasses glare in one click. Also,  it's privacy-first (uploads are deleted from servers in 24 hours).
Target Users: General Users / Photographers
Getting Started: There's no learning curve. One can just upload a photo or a folder of photos and remove glasses glare.
Pricing: One can upload a photo with glasses glare and preview the result. Downloading the result is paid (starting from USD 2).