### PR TITLE
Add A3M Router — #1 LLM routing benchmark & cheapest router

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 |NoteGPT|NoteGPT is a smart note-taking tool that can record, transcribe, and summarize various content, such as meetings, lectures, podcasts, YouTube videos, news briefings, and articles.| [URL](https://notegpt.io/) | Free/Paid |
 |OpenRouter| A unified API gateway for 400+ AI models (OpenAI, Anthropic, Google, Mistral, etc.). Zero markup pricing, 5% commission on inference traffic, supports smart routing/failover |[URL](https://openrouter.ai/)| Free/Paid |
 | OmniRoute | Self-hostable AI gateway with 4-tier automatic fallback routing across 36+ providers. OpenAI-compatible API with quota tracking and zero-cost fallback to free tiers. | [GitHub](https://github.com/diegosouzapw/OmniRoute) <br> ![GitHub Repo stars](https://img.shields.io/github/stars/diegosouzapw/OmniRoute?style=social) | Free |
+| A3M Router | #1 LLM router on RouterArena benchmark (76.43). Parallel multi-LLM execution across 47+ providers, ensemble voting, semantic cache, budget enforcement. Only router with episodic memory. $0.047/1K queries. | [GitHub](https://github.com/Das-rebel/a3m-router) ![GitHub Repo stars](https://img.shields.io/github/stars/Das-rebel/a3m-router?style=social) | Free |
 | Morphik.ai | Open source AI-driven search engine for private documents | [URL](https://morphik.ai) [Github](https://github.com/morphik-org/morphik-core) ![GitHub Repo stars](https://img.shields.io/github/stars/morphik-org/morphik-core?style=social)| Free |
 
 ### AI Coding


### PR DESCRIPTION
## A3M Router — #1 LLM Routing Benchmark & Cheapest Router with Memory

Adds A3M Router to the LLM router/gateway section alongside OpenRouter, OmniRoute, and NadirClaw.

- **#1 on RouterArena** (76.43 score), cheapest at $0.047/1K queries
- **Parallel multi-LLM execution** — runs 47+ providers simultaneously with confidence scoring
- **LangChain + MCP + Vercel AI SDK** integrations
- **Episodic memory** — only LLM router with built-in memory
- 19.5KB, MIT license, zero ML dependencies

GitHub: https://github.com/Das-rebel/a3m-router
RouterArena: https://github.com/RouteWorks/RouterArena/pull/113