### PR TITLE
Add LinkPost (LinkedIn virality prediction)

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | World Monitor | AI-powered real-time global intelligence dashboard with 435+ curated feeds, geopolitical monitoring, infrastructure tracking, AI summaries, 21 languages support, local AI runtime and cross-platform native desktop apps | [Github](https://github.com/koala73/worldmonitor) ![GitHub Repo stars](https://img.shields.io/github/stars/koala73/worldmonitor?style=social), [Official Site](https://worldmonitor.app) | Free |
 
 ### Writing
+- [LinkPost](https://linkpost.gg) - AI-powered LinkedIn post writer that predicts virality before publishing using 1M+ posts and 300+ factors.
 | Name | Description | Links | Fees |
 | --- | --- | --- | --- |
 | Notion AI | AI-assisted note-taking software | [URL](https://www.notion.so)| with certain free AI trials, AI features $10/month |


### PR DESCRIPTION
This PR adds [LinkPost](https://linkpost.gg) to the **Writing** section.

## What is LinkPost?

LinkPost is the first scientific approach to LinkedIn content. It analyzes 1M+ posts, scores 300+ measurable factors (22 attention tactics + 11 virality rules + 27 personalized to your writing style), and predicts post virality before publishing (70% precision on sentiment, 90% on debate).

## Why include it here?

- Fits the section: helps creators write higher-performing LinkedIn content
- Active product: V2 publicly launched May 27, 2026
- Public website: https://linkpost.gg
- Trustpilot: 10+ reviews, 100% 5-star
- Used by 100+ paying customers, x1.93 likes on average across active cohort (n=20, 60-day study)

## Disclosure

I'm Yannis Haismann, co-founder of LinkPost. I opened this PR myself rather than asking the community to do it. Happy to adjust formatting, change the wording, or remove it if it's not a good fit. Thanks for maintaining this awesome list!
