### PR TITLE
Add Whisper Web to Speech Recognition

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | buzz | An open source desktop software based on OpenAI's Whisper to recognize speech and generate subtitles | [GitHub](https://github.com/chidiwilliams/buzz) <br> ![GitHub Repo stars](https://img.shields.io/github/stars/chidiwilliams/buzz?style=social)| Free |
 | WhisperDesktop| Open source, OpenAI-based Whisper, a desktop application for Windows, uses the GPU for processing, which will be faster than on the CPU with good GPU performance.|[GitHub](https://github.com/Const-me/Whisper) ![GitHub Repo stars](https://img.shields.io/github/stars/Const-me/Whisper?style=social)|Free|
 | whisperX | WhisperX: Automatic Speech Recognition with Word-level Timestamps (& Diarization)| [whisperX](https://github.com/m-bain/whisperX) ![GitHub Repo stars](https://img.shields.io/github/stars/m-bain/whisperX?style=social) |Free|
+| Whisper Web | Browser-based transcription running OpenAI's Whisper fully on-device via WebGPU/WebAssembly. No signup, runs entirely in the browser, 100+ languages, exports TXT/SRT/VTT. | [URL](https://whisperweb.dev/) | Free |
 
 ### Text To Speech
 | Name | Description | Links | Fees |


### PR DESCRIPTION
Adds **Whisper Web** (https://whisperweb.dev/) to the Speech Recognition section.

It's a free, browser-based interface for OpenAI's Whisper that runs fully on-device via WebGPU/WebAssembly — no install, no signup, audio never leaves the browser. Supports 100+ languages and exports TXT/SRT/VTT. Complements the existing Whisper entries (whisper, whisper.cpp, buzz) as the zero-setup browser option.