### PR TITLE
Add cv.cm/v to Video Creation

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -256,6 +256,7 @@
 ### AI视频创作
 | 名称 | 说明 | 链接 | 费用 |
 | --- | --- | --- | --- |
+| cv.cm/v | 免排队、满血 Seedance 2.0 文生视频与图生视频，另有 gpt-image-2/Seedream 图像生成、真人人脸、短剧 Agent、无限画布与开放 API |[URL](https://cv.cm/v)|免费/付费|
 | 小云雀 |小云雀app是由字节跳动旗下剪映推出的AI视频和图片创作助手,支持AI智能成片、数字人视频、AI设计、AI换背景等多种功能，可以免费试用seedance 2.0, [Seedance 2.0专题](https://github.com/ikaijua/Awesome-AITools/discussions/266) |[URL](https://xyq.jianying.com/) |试用积分/付费|
 | 豆包 | 字节跳动旗下的AI视频创作助手，支持文生视频、图生视频、数字人视频等多种功能 |[URL](https://www.doubao.com/) |免费/付费|
 | 即梦AI|字节跳动旗下的文生图、AI视频生成和AI图片编辑应用|[URL](https://jimeng.jianying.com/ai-tool/home)|免费/付费|

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 
 | Name | Description | Links | Fees |
 | --- | --- | --- | --- |
+| cv.cm/v | Queue-free, full-power Seedance 2.0 text-to-video & image-to-video, plus gpt-image-2/Seedream images, real-face support, a short-drama agent, an infinite canvas and an open API |[URL](https://cv.cm/v)|Free/Paid|
 | Dreamina|AI image and video creation tool by ByteDance/CapCut. Powered by Seedance 2.0 model. Supports text-to-image, text-to-video, image-to-video with 2K ultra-clear output|[URL](https://dreamina.capcut.com/)|Free/Paid|
 | Wan2.6 |AI Video Creation Tool by Alibaba  | [URL](https://create.wan.video/) | Paid/Free trial |
 | Sora | Sora is an AI model published by OpenAI that can create realistic and imaginative scenes from text instructions. | [URL](https://openai.com/sora) | Paid |


### PR DESCRIPTION
Adds **cv.cm/v** to the Video Creation section (both README.md and README-CN.md).

cv.cm/v is an AI creation studio offering queue-free, full-power **Seedance 2.0** text-to-video and image-to-video, plus gpt-image-2 / Seedream image generation, real human-face support, a one-sentence short-drama agent, an infinite creative canvas, and an open developer API. New users get free credits, then pay-as-you-go — listed as `Free/Paid`.