### PR TITLE
Add Drawtoon to AI Image Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | remove.bg |Remove Image Background|[URL](https://www.remove.bg/)|Free/Paid|
 | ControlNet |ControlNet is a neural network structure to control diffusion models by adding extra conditions.|[Github](https://github.com/lllyasviel/ControlNet) ![GitHub Repo stars](https://img.shields.io/github/stars/lllyasviel/ControlNet?style=social)|Free|
 | PixelPanda | AI-powered platform that creates professional product photos, marketing images, UGC-style videos, and AI avatars — no camera or studio needed. | [URL](https://pixelpanda.ai) | Free/Paid |
+| Drawtoon | AI manga & manhwa studio. Turn a story prompt into full comic pages with consistent characters, panels, and dialogue, then publish to a community feed. | [URL](https://drawtoon.app) | Free/Paid |
 
 ### Video Creation
 


### PR DESCRIPTION
Adds **Drawtoon** to the AI Image Creation table — an AI manga & manhwa studio that turns a story prompt into full comic pages with consistent characters, panels, and dialogue. https://drawtoon.app

Matches the table format. Let me know if you'd like it added to README-CN.md as well. Thanks!