### PR TITLE
Add FlyTrap to AI Agent section

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -130,6 +130,7 @@
 | ECC | 面向 AI 编程代理的开源增强框架。为 Claude Code、Codex、Cursor、OpenCode、Gemini、Zed、GitHub Copilot 等提供统一的 Agent/技能/规则/Hook/MCP 配置体系。内置 60 个子代理、232 个技能、记忆持久化、AgentShield 安全扫描，附带桌面仪表盘 GUI。 | [Github](https://github.com/affaan-m/ECC) ![GitHub Repo stars](https://img.shields.io/github/stars/affaan-m/ECC?style=social) | 免费 |
 | Cua | 面向计算机使用代理 (Computer-Use Agents) 的开源基础设施。提供可在 macOS、Windows、Linux 和 Android 上运行的沙箱、驱动和 SDK，使 AI 能够像人类一样控制桌面并执行任务。[入门介绍](docs/cua/README-CN.md) | [Github](https://github.com/trycua/cua) ![GitHub Repo stars](https://img.shields.io/github/stars/trycua/cua?style=social) | 免费 |
 | AGENTS.md | 专门为 AI 编程智能体设计的代码库文档开放标准。通过提供结构化的上下文、指令和约束条件，帮助智能体更高效、更安全地工作。[入门介绍](docs/agents/README-CN.md) | [Github](https://github.com/agentsmd/agents.md) ![GitHub Repo stars](https://img.shields.io/github/stars/agentsmd/agents.md?style=social) | 免费 |
+|FlyTrap|面向移动应用的探索式测试智能体。像真实测试人员一样探索 Android 和 iOS 应用，发现并报告 Bug、崩溃和用户体验问题，结果可直接提交到 Jira、Linear 和 GitHub。|[URL](https://flytrap.dev/)|付费|
 
 ### Agent Skills
 | 名称 | 说明 | 链接 | 费用 |

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | ECC | Open-source enhancement framework for AI coding agents. Unified agent/skills/rules/Hooks/MCP configuration across Claude Code, Codex, Cursor, OpenCode, Gemini, Zed, GitHub Copilot. Ships with 60 sub-agents, 232 skills, persistent memory, AgentShield security scan, and desktop dashboard GUI. | [Github](https://github.com/affaan-m/ECC) ![GitHub Repo stars](https://img.shields.io/github/stars/affaan-m/ECC?style=social) | Free |
 | Cua | Open-source infrastructure for Computer-Use Agents (CUA). Provides sandboxes, drivers, and SDKs for macOS, Windows, Linux, and Android, enabling AI to control full desktops just like a human. [Intro](docs/cua/README.md) | [Github](https://github.com/trycua/cua) ![GitHub Repo stars](https://img.shields.io/github/stars/trycua/cua?style=social) | Free |
 | AGENTS.md | An open standard for codebase documentation designed specifically for AI coding agents. Provides structured context, instructions, and constraints to help agents work more effectively and safely. [Intro](docs/agents/README.md) | [Github](https://github.com/agentsmd/agents.md) ![GitHub Repo stars](https://img.shields.io/github/stars/agentsmd/agents.md?style=social) | Free |
+|FlyTrap|Exploratory testing agent for mobile apps. Explores Android and iOS builds like a real tester and reports bugs, crashes, and UX issues. Findings are ready to file in Jira, Linear, and GitHub.|[URL](https://flytrap.dev/)|Paid|
 
 ### Agent Skills
 | Name | Description | Links | Fees |


### PR DESCRIPTION
Adds FlyTrap to the AI Agent table in both README.md and README-CN.md to keep the two lists consistent.

FlyTrap is an exploratory testing agent for mobile apps. It explores Android and iOS builds like a real tester and reports bugs, crashes, and UX issues, with findings ready to file in Jira, Linear, and GitHub. Marked as Paid in the Fees column.