### PR TITLE
Add Prismix to News Information section

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | Name | Description | Links | Fees |
 | --- | --- | --- | --- |
 | World Monitor | AI-powered real-time global intelligence dashboard with 435+ curated feeds, geopolitical monitoring, infrastructure tracking, AI summaries, 21 languages support, local AI runtime and cross-platform native desktop apps | [Github](https://github.com/koala73/worldmonitor) ![GitHub Repo stars](https://img.shields.io/github/stars/koala73/worldmonitor?style=social), [Official Site](https://worldmonitor.app) | Free |
+| Prismix | AI hub aggregating real-time status of 75+ AI services (OpenAI, Anthropic, Groq, Cursor, etc.), curated news from 55+ AI sources with a personalized feed, and 500+ MCP server directory with bundles. Email/webhook alerts on outages. | [Official Site](https://prismix.dev) | Free/Paid |
 
 ### Writing
 | Name | Description | Links | Fees |


### PR DESCRIPTION
Adds [Prismix](https://prismix.dev) to the **News Information** section.

Prismix is an all-in-one AI hub with three pillars:
1. **AI News** — curated feed from 55+ sources (Anthropic blog, OpenAI blog, HN AI tag, arXiv ML, etc.) with personalized ranking
2. **Status monitoring** — real-time uptime for 75+ AI services with email/webhook alerts
3. **MCP directory** — 500+ MCP servers with bundles and release tracking

The news pillar is the primary fit for this section, similar to World Monitor.

Live: https://prismix.dev  
News feed: https://prismix.dev/news

Free/Paid (Pro $10/mo for advanced alerts and private bundles).