### PR TITLE
Add Albis to News Information

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | --- | --- | --- | --- |
 | World Monitor | AI-powered real-time global intelligence dashboard with 435+ curated feeds, geopolitical monitoring, infrastructure tracking, AI summaries, 21 languages support, local AI runtime and cross-platform native desktop apps | [Github](https://github.com/koala73/worldmonitor) ![GitHub Repo stars](https://img.shields.io/github/stars/koala73/worldmonitor?style=social), [Official Site](https://worldmonitor.app) | Free |
 | Prismix | AI hub aggregating real-time status of 75+ AI services (OpenAI, Anthropic, Groq, Cursor, etc.), curated news from 55+ AI sources with a personalized feed, and 500+ MCP server directory with bundles. Email/webhook alerts on outages. | [Official Site](https://prismix.dev) | Free/Paid |
+| Albis | AI-assisted news discovery tool that helps readers compare global stories, spot coverage gaps, and use a simple media-literacy feedback prompt. | [Official Site](https://www.albis.news/?utm_source=github&utm_medium=public_catalog&utm_campaign=awesome_aitools_ikaijua) | Free |
 
 ### Writing
 | Name | Description | Links | Fees |


### PR DESCRIPTION
Adds Albis to the News Information section.

Albis is a free AI-assisted news discovery tool that helps readers compare global stories and spot coverage gaps. I'm submitting this on behalf of Albis; the wording is descriptive and does not imply endorsement.

URL uses a UTM parameter so we can understand whether this public catalog route helps people discover the tool.