### PR TITLE
Add Seekstone (Obsidian MCP server)

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -154,6 +154,7 @@
 | 飞书 CLI | 飞书官方命令行工具，帮助开发者快速开发和管理飞书应用 | [Github](https://github.com/larksuite/cli) ![GitHub Repo stars](https://img.shields.io/github/stars/larksuite/cli?style=social) | 免费 |
 | 钉钉 CLI | 钉钉官方命令行工具，帮助开发者快速开发和管理钉钉应用 | [Github](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli) ![GitHub Repo stars](https://img.shields.io/github/stars/DingTalk-Real-AI/dingtalk-workspace-cli?style=social) | 免费 |
 | 企业微信 CLI | 企业微信开源命令行工具，帮助开发者快速开发和管理企业微信应用 | [Github](https://github.com/WecomTeam/wecom-cli) ![GitHub Repo stars](https://img.shields.io/github/stars/WecomTeam/wecom-cli?style=social) | 免费 |
+| Seekstone | 基于文件系统直连的 Obsidian MCP 服务器，让 Claude 直接读写你的 Obsidian 仓库，无需安装 Obsidian 应用或插件。通过 stdio 提供 16 个工具，搜索负载约缩小 575 倍。可通过 `npx -y seekstone` 安装。 | [Github](https://github.com/shaqmughal/seekstone) ![GitHub Repo stars](https://img.shields.io/github/stars/shaqmughal/seekstone?style=social) | 免费 |
 
 ### 开源大语言模型
 | 名称 | 说明 | 链接 | 费用 |

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | Lark CLI | Feishu (Lark) official command-line interface tool, helping developers quickly develop and manage Feishu applications | [Github](https://github.com/larksuite/cli) ![GitHub Repo stars](https://img.shields.io/github/stars/larksuite/cli?style=social) | Free |
 | DingTalk CLI | DingTalk official command-line interface tool for quickly developing and managing DingTalk applications | [Github](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli) ![GitHub Repo stars](https://img.shields.io/github/stars/DingTalk-Real-AI/dingtalk-workspace-cli?style=social) | Free |
 | WeWork CLI | WeCom (WeChat Work) open-source command-line interface tool, helping developers quickly develop and manage WeCom applications | [Github](https://github.com/WecomTeam/wecom-cli) ![GitHub Repo stars](https://img.shields.io/github/stars/WecomTeam/wecom-cli?style=social) | Free |
+| Seekstone | Filesystem-direct Obsidian MCP server that gives Claude direct read/write access to your Obsidian vault with no Obsidian app or plugin required. Exposes 16 tools over stdio with ~575x smaller search payloads. Install via `npx -y seekstone`. | [Github](https://github.com/shaqmughal/seekstone) ![GitHub Repo stars](https://img.shields.io/github/stars/shaqmughal/seekstone?style=social) | Free |
 
 ### Open Source LLMs
 | Name | Description | Links | Fees |


### PR DESCRIPTION
Adds **Seekstone** to the `Office Collaboration CLI/MCP` section in both `README.md` (EN) and `README-CN.md` (CN).

Following the issue #233 template:

- **Tool Name & URL:** Seekstone — https://github.com/shaqmughal/seekstone
- **Core features:** Filesystem-direct Obsidian MCP server. Gives Claude (and any MCP client) direct read/write access to an Obsidian vault straight from disk. 16 tools over stdio: full-text search, scoped reads, writes, link navigation, tags, periodic notes.
- **Key differentiators:** No running Obsidian app and no REST plugin required; returns ~200-char ranked search excerpts instead of full notes (~575x smaller payloads).
- **Target users:** Developers and Obsidian users who want their AI agent to search and edit their vault without burning context.
- **Getting started:** `npx -y seekstone` (set `SEEKSTONE_VAULT` to your vault path).
- **Pricing:** Free / open source (MIT).