### PR TITLE
Add Catoon to AI Image Creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Awesome AI Tools list will be documented in this file.
 
 ## June 2026
+- Added Catoon to AI Image Creation section (both EN/CN)
 - Added ElevenLabs and RVC to Voice Processing section (both EN/CN)
 - Removed Fitten Code from AI Coding section in Chinese README
 - Added yfinance and OpenBB to AI Finance & Quant Investment section (both EN/CN)

--- a/README-CN.md
+++ b/README-CN.md
@@ -258,6 +258,7 @@
 | remove.bg |一键删除图片背景|[URL](https://www.remove.bg/)|免费/付费|
 |ControlNet|能够在一个text2image上训练的扩散模型进行高效finetune，并且结合特定的condition输入，得到可控的效果|[Github](https://github.com/lllyasviel/ControlNet) ![GitHub Repo stars](https://img.shields.io/github/stars/lllyasviel/ControlNet?style=social)|免费|
 |black-forest-labs/flux|FLUX.1 模型的官方推理资源库|[Github](https://github.com/black-forest-labs/flux) ![GitHub Repo stars](https://img.shields.io/github/stars/black-forest-labs/flux?style=social)|免费|
+| Catoon | AI 连载漫画创作工具，可将长篇故事转为可复用角色、分镜、对白气泡、渲染画面和可导出的漫画章节。 | [URL](https://catoon.xyz) | 免费/付费 |
 
 ### AI视频创作
 | 名称 | 说明 | 链接 | 费用 |

--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | remove.bg |Remove Image Background|[URL](https://www.remove.bg/)|Free/Paid|
 | ControlNet |ControlNet is a neural network structure to control diffusion models by adding extra conditions.|[Github](https://github.com/lllyasviel/ControlNet) ![GitHub Repo stars](https://img.shields.io/github/stars/lllyasviel/ControlNet?style=social)|Free|
 | PixelPanda | AI-powered platform that creates professional product photos, marketing images, UGC-style videos, and AI avatars — no camera or studio needed. | [URL](https://pixelpanda.ai) | Free/Paid |
+| Catoon | AI serial comic studio that turns long stories into reusable casts, storyboards, speech bubbles, rendered panels, and export-ready chapters. | [URL](https://catoon.xyz) | Free/Paid |
 
 ### Video Creation
 


### PR DESCRIPTION
Adds Catoon to the AI Image Creation section in both English and Chinese READMEs, plus the June 2026 changelog.\n\nCatoon is an AI serial comic studio for turning long stories into reusable casts, storyboards, speech bubbles, rendered panels, and export-ready chapters.\n\nValidation:\n- Ran `python3 scripts/format_readmes.py`\n- Ran `git diff --check`