### PR TITLE
Add Smart-AI-Bot to AI Agent (中文表)

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -132,6 +132,7 @@
 | AGENTS.md | 专门为 AI 编程智能体设计的代码库文档开放标准。通过提供结构化的上下文、指令和约束条件，帮助智能体更高效、更安全地工作。[入门介绍](docs/agents/README-CN.md) | [Github](https://github.com/agentsmd/agents.md) ![GitHub Repo stars](https://img.shields.io/github/stars/agentsmd/agents.md?style=social) | 免费 |
 | Spec Kit | GitHub 开源的规格驱动开发（Spec-Driven Development）工具包。提供 `specify` CLI 以及 /speckit.specify、/speckit.plan、/speckit.implement 等斜杠命令，与 30+ AI 编程智能体集成，将产品需求规格转化为可执行的实现计划。 | [Github](https://github.com/github/spec-kit) ![GitHub Repo stars](https://img.shields.io/github/stars/github/spec-kit?style=social) | 免费 |
 | Kimi Code | 月之暗面（Moonshot AI）推出的 AI 编程智能体 CLI，在终端中运行。可读取和编辑代码、执行 shell 命令、搜索文件、抓取网页，并根据反馈规划下一步。支持视频输入、AI 原生 MCP 配置、子代理、生命周期钩子以及 ACP 编辑器集成（Zed、JetBrains）。[入门介绍](docs/kimi-code/README-CN.md) | [Github](https://github.com/MoonshotAI/kimi-code) ![GitHub Repo stars](https://img.shields.io/github/stars/MoonshotAI/kimi-code?style=social) | 免费 |
+| Smart-AI-Bot | 由 AI Agent 驱动的 Android UI 自动化测试平台，用自然语言编写用例，在真机上执行并生成可视化回放报告。 | [GitHub](https://github.com/rejigtian/Smart-AI-Bot) | 免费 |
 
 ### Agent Skills
 | 名称 | 说明 | 链接 | 费用 |


### PR DESCRIPTION
在 AI Agent 表格中添加 Smart-AI-Bot（开源，MIT）。
由 AI Agent 驱动的 Android UI 自动化测试平台：用自然语言编写测试用例，LLM 代理在真机上执行并生成可视化回放报告。支持任意网络免 ADB 连接、自学习护栏，可自托管（Docker）。