### PR TITLE
Add OpenPaper to Academic research

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | Lean 4 | An interactive theorem prover and functional programming language, serving as the core infrastructure for formal AI research and automated theorem proving (e.g., AlphaProof, DeepSeek-Prover). | [Github](https://github.com/leanprover/lean4) ![GitHub Repo stars](https://img.shields.io/github/stars/leanprover/lean4?style=social) | Free |
 | AMiner | AI-powered academic research and tech intelligence platform providing paper search, patent search, literature tracking, and scholar profiling | [URL](https://www.aminer.cn/)| Free |
 | alphaxiv | An open academic discussion community based on the arXiv platform that allows users to comment line-by-line, ask questions, and interact in real-time by replacing the paper's linking domain (arxiv.org for alphaxiv.org) directly on the paper's page. And provides AI features such as Ask AI and AI-generated article blogs | [URL](https://www.alphaxiv.org/)| Free |
+| OpenPaper | AI research-paper writer: 18 specialized agents draft structured academic papers with every citation verified against OpenAlex, Crossref, and Semantic Scholar (no hallucinated references). Supports APA/MLA/Chicago/IEEE/Harvard and PDF/DOCX export. The underlying engine is open source (MIT). | [URL](https://openpaper.dev/?utm_source=awesome-aitools&utm_medium=listing) <br> [Github](https://github.com/federicodeponte/opendraft) ![GitHub Repo stars](https://img.shields.io/github/stars/federicodeponte/opendraft?style=social) | Free/Paid |
 
 
 ### OCR


### PR DESCRIPTION
Adds **OpenPaper** ([openpaper.dev](https://openpaper.dev)) to the **Academic research** table.

OpenPaper is an AI research-paper writer: 18 specialized agents draft structured academic papers with every citation **verified against OpenAlex, Crossref, and Semantic Scholar** (no hallucinated references). Supports APA/MLA/Chicago/IEEE/Harvard and PDF/DOCX export. Free tier available.

The underlying engine is open source under the MIT license: https://github.com/federicodeponte/opendraft

Entry follows the existing `| Name | Description | Links | Fees |` table format and sits alongside AMiner, alphaxiv, etc.