### PR TITLE
Add AI Weekly to News Information section

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
   - [LLM Prompts](#llm-prompts)
   - [LLM training platform](#llm-training-platform)
   - [News Information](#news-information)
-| AI Weekly | Independent AI news newsletter, 3x/week since 2015, read by 44,000+ professionals. The few AI stories that matter, solo-edited. Proprietary AI Weekly Index, quarterly State-of-AI recap, Who's-Who-of-AI graph (2,335 figures), and an 11-year archive. | [Official Site](https://aiweekly.co) | Free |
   - [Writing](#writing)
   - [Translation](#translation)
   - [Speech Recognition](#speech-recognition)
@@ -301,6 +300,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | --- | --- | --- | --- |
 | World Monitor | AI-powered real-time global intelligence dashboard with 435+ curated feeds, geopolitical monitoring, infrastructure tracking, AI summaries, 21 languages support, local AI runtime and cross-platform native desktop apps | [Github](https://github.com/koala73/worldmonitor) ![GitHub Repo stars](https://img.shields.io/github/stars/koala73/worldmonitor?style=social), [Official Site](https://worldmonitor.app) | Free |
 | Prismix | AI hub aggregating real-time status of 75+ AI services (OpenAI, Anthropic, Groq, Cursor, etc.), curated news from 55+ AI sources with a personalized feed, and 500+ MCP server directory with bundles. Email/webhook alerts on outages. | [Official Site](https://prismix.dev) | Free/Paid |
+| AI Weekly | Independent AI news newsletter, 3x/week since 2015, read by 44,000+ professionals. The few AI stories that matter, solo-edited. Proprietary AI Weekly Index, quarterly State-of-AI recap, Who's-Who-of-AI graph (2,335 figures), and an 11-year archive. | [Official Site](https://aiweekly.co) | Free |
 
 ### Writing
 | Name | Description | Links | Fees |

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
   - [LLM Prompts](#llm-prompts)
   - [LLM training platform](#llm-training-platform)
   - [News Information](#news-information)
+| AI Weekly | Independent AI news newsletter, 3x/week since 2015, read by 44,000+ professionals. The few AI stories that matter, solo-edited. Proprietary AI Weekly Index, quarterly State-of-AI recap, Who's-Who-of-AI graph (2,335 figures), and an 11-year archive. | [Official Site](https://aiweekly.co) | Free |
   - [Writing](#writing)
   - [Translation](#translation)
   - [Speech Recognition](#speech-recognition)


### PR DESCRIPTION
Adds AI Weekly (https://aiweekly.co) to the News Information section — an independent, solo-edited AI news newsletter running 3x/week since 2015 with 44,000+ professional readers, covering the few AI stories that matter. It fits alongside the existing curated-news entries (World Monitor, Prismix) and brings proprietary signal: the AI Weekly Index, a quarterly State-of-AI recap, a Who's-Who-of-AI graph of 2,335 figures, and an 11-year archive. (Distinct from ai-weekly.ai, weeklyreport.ai, and the defunct VentureBeat AI Weekly.)