### PR TITLE
Add BuyWhere MCP server to Office Collaboration CLI/MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | Lark CLI | Feishu (Lark) official command-line interface tool, helping developers quickly develop and manage Feishu applications | [Github](https://github.com/larksuite/cli) ![GitHub Repo stars](https://img.shields.io/github/stars/larksuite/cli?style=social) | Free |
 | DingTalk CLI | DingTalk official command-line interface tool for quickly developing and managing DingTalk applications | [Github](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli) ![GitHub Repo stars](https://img.shields.io/github/stars/DingTalk-Real-AI/dingtalk-workspace-cli?style=social) | Free |
 | WeWork CLI | WeCom (WeChat Work) open-source command-line interface tool, helping developers quickly develop and manage WeCom applications | [Github](https://github.com/WecomTeam/wecom-cli) ![GitHub Repo stars](https://img.shields.io/github/stars/WecomTeam/wecom-cli?style=social) | Free |
+| BuyWhere | Cross-border e-commerce MCP server. Search 11M+ products across Singapore, SEA, and US markets with real-time price comparison and deal discovery for AI agents. | [Github](https://github.com/BuyWhere/buywhere-mcp) ![GitHub Repo stars](https://img.shields.io/github/stars/BuyWhere/buywhere-mcp?style=social) | Free |
 
 ### Open Source LLMs
 | Name | Description | Links | Fees |


### PR DESCRIPTION
## Summary

Adds [BuyWhere](https://github.com/BuyWhere/buywhere-mcp) MCP server to the Office Collaboration CLI/MCP section.

BuyWhere is a cross-border e-commerce MCP server that enables AI agents to search 11M+ products across Singapore, SEA, and US markets with real-time price comparison and deal discovery.

## What it does

- Provides  tool for natural-language product search across multiple merchants
- Supports price comparison, deal alerts, and merchant filtering
- Available via `npx @buywhere/mcp-server` — no API key required for basic use
- Built-in support for Claude Desktop, Cursor, VS Code, and other MCP-compatible clients