### PR TITLE
Add BuyWhere MCP server to Office Collaboration CLI/MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | Lark CLI | Feishu (Lark) official command-line interface tool, helping developers quickly develop and manage Feishu applications | [Github](https://github.com/larksuite/cli) ![GitHub Repo stars](https://img.shields.io/github/stars/larksuite/cli?style=social) | Free |
 | DingTalk CLI | DingTalk official command-line interface tool for quickly developing and managing DingTalk applications | [Github](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli) ![GitHub Repo stars](https://img.shields.io/github/stars/DingTalk-Real-AI/dingtalk-workspace-cli?style=social) | Free |
 | WeWork CLI | WeCom (WeChat Work) open-source command-line interface tool, helping developers quickly develop and manage WeCom applications | [Github](https://github.com/WecomTeam/wecom-cli) ![GitHub Repo stars](https://img.shields.io/github/stars/WecomTeam/wecom-cli?style=social) | Free |
+| BuyWhere MCP | An MCP server from BuyWhere that gives AI agents real-time product search and price comparison across 11M+ products in Shopee, Lazada, Amazon, Walmart, and 20+ retailers in Singapore, SEA, and US. Free API key (no signup), streamable-HTTP at api.buywhere.ai/mcp, stdio via `npx @buywhere/mcp-server`. Published on the official MCP Registry as `io.github.BuyWhere/buywhere-mcp@1.0.5`. | [Github](https://github.com/BuyWhere/buywhere-mcp) ![GitHub Repo stars](https://img.shields.io/github/stars/BuyWhere/buywhere-mcp?style=social) | Free |
 
 ### Open Source LLMs
 | Name | Description | Links | Fees |


### PR DESCRIPTION
## Add BuyWhere MCP server to Office Collaboration CLI/MCP

Adds BuyWhere MCP to the `### Office Collaboration CLI/MCP` section (alongside Chrome DevTools MCP, Lightpanda, bb-browser, Google Workspace CLI, Lark CLI, DingTalk CLI, WeWork CLI).

### Why it fits
- It's an MCP server that gives AI agents new CLI/MCP capabilities (real-time product search and price comparison)
- Free and open-source, fits the "Fees: Free" column
- Same Markdown table format as existing entries (Name | Description | Links | Fees)

### About BuyWhere
BuyWhere is an MCP server that exposes 11M+ products across Shopee, Lazada, Amazon, Walmart, and 20+ retailers in Singapore, SEA, and US, with 7 tools (`search_products`, `get_product`, `compare_products`, `find_best_price`, `get_deals`, `list_categories`, `find_similar`). Streamable-HTTP at `https://api.buywhere.ai/mcp`, stdio via `npx @buywhere/mcp-server`. Free API key (3-second `POST /v1/auth/register`), auto-publishes to the MCP Registry on every release.