### PR TITLE
Add AI Money Stack

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -213,6 +213,7 @@
 ### AI Coding
 | 名称 | 说明 | 链接 | 费用 |
 | --- | --- | --- | --- |
+| AI Money Stack | 面向独立开发者的本地优先付费工具包：整理收入想法、生成 PR review notes、筛选付费 OSS bounty 候选，无需 API key 或云端上传。 | [URL](https://duct-tape2.github.io/ai-money-stack/) | 付费 |
 | mahonzhan/awesome-coding-plan|各厂家 Coding Plan 对比|[Github](https://github.com/mahonzhan/awesome-coding-plan) ![GitHub Repo stars](https://img.shields.io/github/stars/mahonzhan/awesome-coding-plan?style=social) |免费|
 | Trae | 字节跳动推出的类似Cursor的AI编程IDE|[URL](http://trae.com.cn)|免费|
 | Cursor | 使用 GPT进行协作的代码编辑器 | [URL](https://www.cursor.so) | 付费/免费试用 |

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 ### AI Coding
 | Name | Description | Links | Fees |
 | --- | --- | --- | --- |
+| AI Money Stack | Local-first paid toolkit for indie developers: ranks revenue ideas, generates PR review notes, and filters paid OSS bounty candidates without API keys or cloud upload. | [URL](https://duct-tape2.github.io/ai-money-stack/) | Paid |
 | Cursor | A collaborative code editor using GPT | [URL](https://www.cursor.so) | Paid/Free Trial |
 | GitHub Copilot | A code writing assistant developed by GitHub and OpenAI | [URL](https://github.com/features/copilot) | Paid|
 | dbForge AI Assistant | AI-powered tool that generates, optimizes, and troubleshoots SQL code; indispensable for developers, DBAs, and analysts | [URL](https://www.devart.com/dbforge/ai-assistant/) | Paid/Free Trial|


### PR DESCRIPTION
Adds AI Money Stack to the AI Coding section in both English and Chinese READMEs.

Disclosure: I am connected with this tool, and it is listed as a paid resource.

- **Tool Name & URL**: AI Money Stack — https://duct-tape2.github.io/ai-money-stack/
- **Free Preview**: https://duct-tape2.github.io/examples/ai-money-stack-sample-output/
- **Core Features**: Local-first toolkit for indie builders that includes revenue idea scanning, PR review checklists, launch checklists, and marketing copy templates.
- **Key Differentiators**: Focuses on small-builder revenue workflows and ships as downloadable local templates/checklists rather than a hosted AI chat app.
- **Target Users**: Developers & Programmers; Content Creators; indie builders.
- **Getting Started**: Public landing page and free preview release are linked from the project page.
- **Pricing**: Paid product, $25. Free preview assets are available from the GitHub release.
- **Other**: Kept the list entry short and factual in both English and Chinese README files.