### PR TITLE
Add Letterfork to Writing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | Obsidian | Powerful local-first markdown note-taking tool with extensive AI plugin ecosystem - supports AI summarization, RAG, and intelligent note processing via community plugins | [URL](https://obsidian.md/) | Free/Paid|
 | Deep L Write | English and German writing tools to fix writing errors and rewrite sentences promptly. | [URL](https://www.deepl.com/write) | Free version to use with text word limit / paid upgrade available |
 | grammarly | Edit and correct your grammar, spelling, punctuation, and more with your personal writing assistant, grammar checker, and editor.| [URL](https://app.grammarly.com/) | Free/Paid|
+| Letterfork | Turns one newsletter issue into 7 platform-native social posts (LinkedIn, X, Bluesky, Substack Notes, Threads, Instagram, Reddit) in the writer's own voice. Paste a Substack/Beehiiv/Ghost URL, get posts in about 60 seconds. | [URL](https://www.letterfork.com) | Free/Paid |
 
 
 


### PR DESCRIPTION
Resubmission of #523 (auto-closed by the stale bot on 2026-05-26 before review), rebased on current main.

**Tool Name & URL**: Letterfork — https://www.letterfork.com

**Core Features**: Paste a Substack / Beehiiv / Ghost newsletter URL (or raw text) and Letterfork rewrites the issue into 7 platform-native social posts — LinkedIn, X, Bluesky, Substack Notes, Threads, Instagram, Reddit — in about 60 seconds. Each output follows that platform's real conventions (LinkedIn hook-led single-sentence paragraphs, Bluesky 300-char chains without thread tics, Reddit member-not-marketer tone, etc.).

**Key Differentiators**: Voice cloning from the writer's past issues (rhythm, openers, vocabulary — not just topics), so output reads like the author rather than generic AI. Newsletter-first: it's the only tool in this space that starts from a newsletter rather than a podcast/video. Never auto-publishes — the writer reviews and posts.

**Target Users**: Newsletter writers (Substack / Beehiiv / Ghost) who repurpose issues for social platforms.

**Getting Started**: Sign up free at https://www.letterfork.com — 3 lifetime rewrites across all 7 platforms, no credit card.

**Pricing**: Free tier; paid plans $9 / $19 / $39 per month.

**Other**: Built by a solo founder who writes The Super Lede on Substack. llms.txt available at https://www.letterfork.com/llms.txt.