### PR TITLE
Add ImageBench to AI Image Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | clipdrop | clipdrop by stability.ai. Has many AI image processing tools, such as stable diffusion XL, uncrop, reimage XL, stable doodle. | [URL](https://clipdrop.co/) | Free/Paid |
 | firefly | Adobe's AI image processing web site |[URL](https://firefly.adobe.com/)|Free/Paid|
 | ideogram.ai | Enter text to create pictures. A product developed by a company founded by many ex-Googlers |[URL](https://ideogram.ai/)| Free/Paid |
+| ImageBench | Benchmark and comparison site for text-to-image models, with side-by-side results, pass-rate summaries, and methodology pages. | [URL](https://imagebench.ai/) | Free |
 | Nero AI | AI picture upscale, AI repair scratches, AI picture coloring, AI picture noise removal, AI one-click to change the background, AI magical erasing pen, AI portrait. API doc：https://ai.nero.com/ai-api/docs/|[URL](https://ai.nero.com/)|Paid/Trial|
 | Skybox AI | Generate 360-degree panoramic images using text prompts  | [URL](https://skybox.blockadelabs.com/)| Free/Paid|
 | remove.bg |Remove Image Background|[URL](https://www.remove.bg/)|Free/Paid|


### PR DESCRIPTION
Adds ImageBench to the AI Image Creation section as a text-to-image benchmark and comparison resource. Happy to adjust wording if you prefer a different description or placement.