### PR TITLE
Add Use AI For — profession-organized AI tools directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | World Monitor | AI-powered real-time global intelligence dashboard with 435+ curated feeds, geopolitical monitoring, infrastructure tracking, AI summaries, 21 languages support, local AI runtime and cross-platform native desktop apps | [Github](https://github.com/koala73/worldmonitor) ![GitHub Repo stars](https://img.shields.io/github/stars/koala73/worldmonitor?style=social), [Official Site](https://worldmonitor.app) | Free |
 | Prismix | AI hub aggregating real-time status of 75+ AI services (OpenAI, Anthropic, Groq, Cursor, etc.), curated news from 55+ AI sources with a personalized feed, and 500+ MCP server directory with bundles. Email/webhook alerts on outages. | [Official Site](https://prismix.dev) | Free/Paid |
 | AI Weekly | Independent AI news newsletter, 3x/week since 2015, read by 44,000+ professionals. The few AI stories that matter, solo-edited. Proprietary AI Weekly Index, quarterly State-of-AI recap, Who's-Who-of-AI graph (2,335 figures), and an 11-year archive. | [Official Site](https://aiweekly.co) | Free |
+| Use AI For | AI tools directory organized by profession — groups tools by job role (accountants, lawyers, nurses, etc.) so non-technical professionals can find AI relevant to their work | [Official Site](https://use-ai-for.com) | Free |
 
 ### Writing
 | Name | Description | Links | Fees |


### PR DESCRIPTION
Adding Use AI For to the News Information section (alongside other AI aggregator/meta tools like Prismix and AI Weekly).

Per the issue #233 template:

- **Tool Name & URL**: Use AI For — https://use-ai-for.com
- **Core Features**: Directory of AI tools grouped by profession (accountants, lawyers, plumbers, nurses, etc.) rather than by feature category. Makes it easy for non-technical professionals to find AI tools relevant to their specific job role.
- **Key Differentiators**: Profession-first organization — most AI directories group by feature (writing, coding, image generation); Use AI For groups by who uses the tool, not what it does.
- **Target Users**: General Users / Enterprise Users — specifically non-technical professionals looking for job-relevant AI tools
- **Getting Started**: Browse by profession at https://use-ai-for.com
- **Pricing**: Free to use
- **Other**: Also publishes an llms.txt at https://use-ai-for.com/llms.txt

Disclosure: I represent the site.