### PR TITLE
Add AI Nexus to Writing category

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | Obsidian | Powerful local-first markdown note-taking tool with extensive AI plugin ecosystem - supports AI summarization, RAG, and intelligent note processing via community plugins | [URL](https://obsidian.md/) | Free/Paid|
 | Deep L Write | English and German writing tools to fix writing errors and rewrite sentences promptly. | [URL](https://www.deepl.com/write) | Free version to use with text word limit / paid upgrade available |
 | grammarly | Edit and correct your grammar, spelling, punctuation, and more with your personal writing assistant, grammar checker, and editor.| [URL](https://app.grammarly.com/) | Free/Paid|
+| AI Nexus | Independent reviews and side-by-side comparisons of AI writing, coding, video, and voice tools, with dedicated India pricing breakdowns. | [URL](https://ainexustools.online) | Free |
 
 
 


### PR DESCRIPTION
Adding AI Nexus (ainexustools.online) to the Writing table - an independent AI tool review/comparison site with dedicated India-market pricing breakdowns. Note: I've also opened issue #[your issue number] using the recommendation template, in case that's the preferred path - happy to close whichever one doesn't fit your workflow.