### PR TITLE
Add PulseGate to News Information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Awesome AI Tools list will be documented in this file.
 
 ## July 2026
+- Added PulseGate to News Information section (both EN/CN)
 - Renamed the News Information section to "AI News & Information" (both EN/CN)
 - Added SemiAnalysis to the top of the News Information section with its X link (both EN/CN)
 - Moved Kimi Code and Grok Build after Codex in AI Agent section (both EN/CN)

--- a/README-CN.md
+++ b/README-CN.md
@@ -239,6 +239,7 @@
 | --- | --- | --- | --- |
 | SemiAnalysis | 由 Dylan Patel 创办，专注于半导体、AI 硬件、GPU、数据中心及算力供应链的深度研究与分析。发布对 AI 行业有深入研究的长篇行业研报（部分免费，大部分需订阅）。 | [X](https://x.com/SemiAnalysis_)、[官网](https://semianalysis.com) | 免费/付费 |
 | World Monitor | AI驱动的实时全球情报面板，聚合435+个精选信源，提供地缘政治监控、基础设施追踪、AI摘要、21种语言支持，可本地运行AI模型，支持全平台桌面端应用 | [Github](https://github.com/koala73/worldmonitor) ![GitHub Repo stars](https://img.shields.io/github/stars/koala73/worldmonitor?style=social)、[官网](https://worldmonitor.app) | 免费 |
+| PulseGate | AI 时代软件的自动化索引：约 17.5 万个应用、模型、智能体与基础设施工具，上线即收录。提供免费公开统计 API、RSS 订阅与可嵌入组件 | [官网](https://www.pulsegate.ai) | 免费 |
 
 ### AI金融与量化投资
 | 名称 | 说明 | 链接 | 费用 |

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | World Monitor | AI-powered real-time global intelligence dashboard with 435+ curated feeds, geopolitical monitoring, infrastructure tracking, AI summaries, 21 languages support, local AI runtime and cross-platform native desktop apps | [Github](https://github.com/koala73/worldmonitor) ![GitHub Repo stars](https://img.shields.io/github/stars/koala73/worldmonitor?style=social), [Official Site](https://worldmonitor.app) | Free |
 | Prismix | AI hub aggregating real-time status of 75+ AI services (OpenAI, Anthropic, Groq, Cursor, etc.), curated news from 55+ AI sources with a personalized feed, and 500+ MCP server directory with bundles. Email/webhook alerts on outages. | [Official Site](https://prismix.dev) | Free/Paid |
 | AI Weekly | Independent AI news newsletter, 3x/week since 2015, read by 44,000+ professionals. The few AI stories that matter, solo-edited. Proprietary AI Weekly Index, quarterly State-of-AI recap, Who's-Who-of-AI graph (2,335 figures), and an 11-year archive. | [Official Site](https://aiweekly.co) | Free |
+| PulseGate | Live index of AI-era software: ~175k apps, models, agents and infrastructure tools, indexed continuously as they ship. Free public stats API, RSS feeds and an embeddable widget | [Official Site](https://www.pulsegate.ai) | Free |
 
 ### AI Finance & Quant Investment
 | Name | Description | Links | Fees |


### PR DESCRIPTION
Adds PulseGate to News Information (both README.md and README-CN.md), plus a CHANGELOG.md entry.

Disclosure: I'm from the PulseGate team (Dymaxio s.r.o., Prague).

PulseGate (pulsegate.ai) is a live index of AI-era software — apps, models, agents and infrastructure — currently ~175,000 tracked, indexed as they ship rather than on a curation cycle. No editorial gate, no ranking, no pay-to-play. Free public stats JSON (/api/stats/public), RSS feeds, and an embeddable widget; methodology and a copy-paste citation at pulsegate.ai/press.

Fits News Information as a live, no-gatekeeper discovery resource alongside Prismix (closest structural analogue — both are aggregator/hub tools rather than individual products).

Note: the Chinese News Information section doesn't currently have a translated row for the English-only "AI Weekly" entry, so I appended the PulseGate row after the section's last existing CN entry (World Monitor) to keep both languages in sync per AGENTS.md.

Ran `python3 scripts/format_readmes.py` after editing, per AGENTS.md.