### PR TITLE
docs: add AI Router to AI Cloud Platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Awesome AI Tools list will be documented in this file
 - Added last30days-skill (mvanhorn/last30days-skill) to Agent Skills section (both EN/CN)
 - Added DeepTutor (HKUDS/DeepTutor) to AI Agent section with documentation (both EN/CN)
 - Added FlowGram.AI (bytedance/flowgram.ai) to AI Agent section (both EN/CN)
+- Added AI Router to AI Cloud Platform (English root link and Chinese localized link)
 - Renamed the News Information section to "AI News & Information" (both EN/CN)
 - Added SemiAnalysis to the top of the News Information section with its X link (both EN/CN)
 - Moved Kimi Code and Grok Build after Codex in AI Agent section (both EN/CN)

--- a/README-CN.md
+++ b/README-CN.md
@@ -307,6 +307,7 @@
 | 名称 | 说明 | 链接 | 费用 |
 | --- | --- | --- | --- |
 | Together AI |Together AI是一个专为生成式AI设计的云平台，提供了从模型推理、微调到GPU集群部署等多种服务。相比其他传统云平台，Together AI 主要聚焦于高效处理开源生成式模型，并为开发者和企业提供更灵活、定制化的解决方案。Together AI 支持多个开源模型，包括 LLaMA、Falcon、FLUX1 等。这些模型覆盖了从自然语言处理、对话系统到代码生成等多个领域，满足了不同场景下的应用需求。用户可以直接调用这些模型，也可以上传自己的数据进行微调，提升模型在特定任务中的表现。 文章介绍:<br> [Together AI是一个生成式AI服务平台](https://mp.weixin.qq.com/s/qyFPqlotBayTDHaZSmSogw) |[URL](https://www.together.ai/)|免费/付费|
+| AI Router | 面向开发者的独立 OpenAI 兼容 API 服务。可使用个人 API Key 配置 Base URL，并按 Key 查看用量；当前模型可用性以 `/v1/models` 查询结果为准。非 OpenAI 官方服务。 | [URL](https://ai-router.dev/cn) | 付费 |
 
 ### GPU编程
 | 名称 | 说明 | 链接 | 费用 |

--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | Name | Description | Links | Fees |
 | --- | --- | --- | --- |
 |together.ai|The AI Acceleration Cloud. Train, fine-tune-and run inference on AI models blazing fast, at low cost, and at production scale.|[URL](https://www.together.ai/) |Free/Paid|
+| AI Router | Independent OpenAI-compatible API service for developers. Use a personal API key with a configurable base URL and review usage per key; query current model availability through `/v1/models`. Not affiliated with OpenAI. | [URL](https://ai-router.dev) | Paid |
 
 ### GPU Programming
 | Name | Description | Links | Fees |


### PR DESCRIPTION
## Tool recommendation

- **Tool name and URL:** AI Router — https://ai-router.dev
- **Core functionality:** Independent OpenAI-compatible API service for developers. It supports a personal API key, configurable base URL, per-key usage visibility, and current model discovery through `/v1/models`.
- **Target users:** Developers and programmers.
- **Pricing:** Paid. This submission makes no trial, credit, fixed-model, or reliability claim.
- **Localization:** The English entry uses the root URL; the Chinese entry uses https://ai-router.dev/cn.
- **Disclosure:** I operate AI Router. It is not affiliated with OpenAI.