### PR TITLE
Add light-ocr to OCR tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Awesome AI Tools list will be documented in this file.
 
 ## July 2026
+- Added light-ocr to the OCR section (both EN/CN)
 - Renamed the News Information section to "AI News & Information" (both EN/CN)
 - Added SemiAnalysis to the top of the News Information section with its X link (both EN/CN)
 - Moved Kimi Code and Grok Build after Codex in AI Agent section (both EN/CN)

--- a/README-CN.md
+++ b/README-CN.md
@@ -440,6 +440,7 @@
 | --- | --- | --- | --- |
 |微信|微信对话框中的图片有提取文字的选项，识别效果很好，使用了几次基本没有什么识别错误。<br> [2021-03月份 微信AI对OCR功能的介绍：三年磨一剑——微信OCR图片文字提取](https://mp.weixin.qq.com/s/8Odh9TKKoxIYDpr1h-5Y5Q)||免费|
 |Umi-OCR|开源、免费的离线OCR软件。支持截屏/粘贴/批量导入图片，段落排版/排除水印，扫描/生成二维码。内置多国语言库。|[Github](https://github.com/hiroi-sora/Umi-OCR) ![GitHub Repo stars](https://img.shields.io/github/stars/hiroi-sora/Umi-OCR?style=social)|免费|
+|light-ocr|面向 Node.js 和 C++ 的快速离线 OCR，内置 PP-OCRv6 模型和跨平台运行时。|[Github](https://github.com/arcships/light-ocr) ![GitHub Repo stars](https://img.shields.io/github/stars/arcships/light-ocr?style=social)|免费|
 |allenai/olmocr|一个用于训练语言模型以处理实际PDF文档的工具包。Demo网址: https://olmocr.allenai.org/|[Github](https://github.com/allenai/olmocr) ![GitHub Repo stars](https://img.shields.io/github/stars/allenai/olmocr?style=social)|免费|
 
 ### 视频内容总结

--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | Name | Description | Links | Fees |
 | --- | --- | --- | --- |
 |Umi-OCR|Comes with a highly efficient offline OCR engine. As long as the computer performance is sufficient, it can be faster than online OCR services.|[Github](https://github.com/hiroi-sora/Umi-OCR) ![GitHub Repo stars](https://img.shields.io/github/stars/hiroi-sora/Umi-OCR?style=social)|Free|
+|light-ocr|Fast, offline OCR for Node.js and C++ with bundled PP-OCRv6 models and cross-platform runtimes.|[Github](https://github.com/arcships/light-ocr) ![GitHub Repo stars](https://img.shields.io/github/stars/arcships/light-ocr?style=social)|Free|
 |allenai/olmocr|A toolkit for training language models to work with PDF documents in the wild. Online demo: https://olmocr.allenai.org/|[Github](https://github.com/allenai/olmocr) ![GitHub Repo stars](https://img.shields.io/github/stars/allenai/olmocr?style=social)|Free|
 
 


### PR DESCRIPTION
Adds light-ocr to the OCR section in both English and Chinese, and records the addition in the July 2026 changelog.

light-ocr is a fast, offline OCR library and CLI for Node.js and C++, with bundled PP-OCRv6 models and cross-platform runtimes.

Validation:
- Ran `python3 scripts/format_readmes.py`
- Confirmed the diff passes `git diff --check`