### PR TITLE
Add Free AI Directory CN to AI News & Information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Awesome AI Tools list will be documented in this file.
 
 ## July 2026
+- Added Free AI Directory CN to AI News & Information section (both EN/CN)
 - Renamed the News Information section to "AI News & Information" (both EN/CN)
 - Added SemiAnalysis to the top of the News Information section with its X link (both EN/CN)
 - Moved Kimi Code and Grok Build after Codex in AI Agent section (both EN/CN)

--- a/README-CN.md
+++ b/README-CN.md
@@ -240,6 +240,7 @@
 | --- | --- | --- | --- |
 | SemiAnalysis | 由 Dylan Patel 创办，专注于半导体、AI 硬件、GPU、数据中心及算力供应链的深度研究与分析。发布对 AI 行业有深入研究的长篇行业研报（部分免费，大部分需订阅）。 | [X](https://x.com/SemiAnalysis_)、[官网](https://semianalysis.com) | 免费/付费 |
 | World Monitor | AI驱动的实时全球情报面板，聚合435+个精选信源，提供地缘政治监控、基础设施追踪、AI摘要、21种语言支持，可本地运行AI模型，支持全平台桌面端应用 | [Github](https://github.com/koala73/worldmonitor) ![GitHub Repo stars](https://img.shields.io/github/stars/koala73/worldmonitor?style=social)、[官网](https://worldmonitor.app) | 免费 |
+| 免费 AI 目录 | 独立中文目录，每日整理 AI 新闻、热门项目、趋势模型，并收录可核验的免费模型与 Codex/Claude Code 中转站公开信息。无需注册、无广告、不接收 API Key。 | [网站](https://www.qaz5678.xyz/) | 免费 |
 
 ### AI金融与量化投资
 | 名称 | 说明 | 链接 | 费用 |

--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | World Monitor | AI-powered real-time global intelligence dashboard with 435+ curated feeds, geopolitical monitoring, infrastructure tracking, AI summaries, 21 languages support, local AI runtime and cross-platform native desktop apps | [Github](https://github.com/koala73/worldmonitor) ![GitHub Repo stars](https://img.shields.io/github/stars/koala73/worldmonitor?style=social), [Official Site](https://worldmonitor.app) | Free |
 | Prismix | AI hub aggregating real-time status of 75+ AI services (OpenAI, Anthropic, Groq, Cursor, etc.), curated news from 55+ AI sources with a personalized feed, and 500+ MCP server directory with bundles. Email/webhook alerts on outages. | [Official Site](https://prismix.dev) | Free/Paid |
 | AI Weekly | Independent AI news newsletter, 3x/week since 2015, read by 44,000+ professionals. The few AI stories that matter, solo-edited. Proprietary AI Weekly Index, quarterly State-of-AI recap, Who's-Who-of-AI graph (2,335 figures), and an 11-year archive. | [Official Site](https://aiweekly.co) | Free |
+| Free AI Directory CN | Independent Chinese directory for daily AI news, trending projects, free model links, and source-backed Codex/Claude Code relay information. No registration, ads, affiliate ranking, or API key collection. | [Official Site](https://www.qaz5678.xyz/) | Free |
 
 ### AI Finance & Quant Investment
 | Name | Description | Links | Fees |


### PR DESCRIPTION
## Summary

- Adds Free AI Directory CN to the AI News & Information section in both English and Chinese.
- Updates the July 2026 changelog.
- The site is an independent Chinese directory for daily AI news, trending projects, free model links, and source-backed Codex/Claude Code relay information. It requires no registration and does not collect API keys.

## Verification

- Ran python3 scripts/format_readmes.py
- Verified the public site: https://www.qaz5678.xyz/

Disclosure: the wording and mechanical edits were prepared with AI assistance and reviewed before submission.