### PR TITLE
Add Gpt to GPT LLMs Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | OmniRoute | Self-hostable AI gateway with 4-tier automatic fallback routing across 36+ providers. OpenAI-compatible API with quota tracking and zero-cost fallback to free tiers. | [GitHub](https://github.com/diegosouzapw/OmniRoute) <br> ![GitHub Repo stars](https://img.shields.io/github/stars/diegosouzapw/OmniRoute?style=social) | Free |
 | Morphik.ai | Open source AI-driven search engine for private documents | [URL](https://morphik.ai) [Github](https://github.com/morphik-org/morphik-core) ![GitHub Repo stars](https://img.shields.io/github/stars/morphik-org/morphik-core?style=social)| Free |
 | Future AGI | Open-source platform to simulate, evaluate, trace, guardrail, route, and optimize LLM and AI agent apps in one feedback loop, so agents don't just get monitored, they self-improve. Self-hostable. Apache-2.0. | [Github](https://github.com/future-agi/future-agi) ![GitHub Repo stars](https://img.shields.io/github/stars/future-agi/future-agi?style=social) | Free |
+| Gpt | AI tool for productivity, content workflows, research, and daily work. | [URL](https://trygrokai.asia/) | Free daily quota; limits may apply |
 
 ### AI Coding
 | Name | Description | Links | Fees |


### PR DESCRIPTION
This PR adds Gpt to the English GPT LLMs Applications section.

- Website: https://trygrokai.asia/
- Description: AI tool for productivity, content workflows, research, and daily work.
- Pricing: Free daily quota; limits may apply.

The entry uses the canonical HTTPS URL without tracking parameters and follows the repository's recommendation format. Submitted by the product owner/operator.