### PR TITLE
Add AICareerPivot to GPT LLMs Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | OmniRoute | Self-hostable AI gateway with 4-tier automatic fallback routing across 36+ providers. OpenAI-compatible API with quota tracking and zero-cost fallback to free tiers. | [GitHub](https://github.com/diegosouzapw/OmniRoute) <br> ![GitHub Repo stars](https://img.shields.io/github/stars/diegosouzapw/OmniRoute?style=social) | Free |
 | Morphik.ai | Open source AI-driven search engine for private documents | [URL](https://morphik.ai) [Github](https://github.com/morphik-org/morphik-core) ![GitHub Repo stars](https://img.shields.io/github/stars/morphik-org/morphik-core?style=social)| Free |
 | Future AGI | Open-source platform to simulate, evaluate, trace, guardrail, route, and optimize LLM and AI agent apps in one feedback loop, so agents don't just get monitored, they self-improve. Self-hostable. Apache-2.0. | [Github](https://github.com/future-agi/future-agi) ![GitHub Repo stars](https://img.shields.io/github/stars/future-agi/future-agi?style=social) | Free |
+| AICareerPivot | Free AI-powered career pivot roadmap builder — maps skill gaps, builds personalized transition timelines, and generates resumes, mock interviews & LinkedIn optimization for career changers. | [AICareerPivot](https://ai-career-pivot.com) | Free |
 
 ### AI Coding
 | Name | Description | Links | Fees |


### PR DESCRIPTION
Adds **AICareerPivot** (https://ai-career-pivot.com) to the GPT LLMs Applications table, per the submission template in #233.

- **Tool Name & URL**: AICareerPivot — https://ai-career-pivot.com
- **Core Features**: Free AI-powered career pivot roadmap builder — maps skill gaps, builds personalized transition timelines, and generates resumes, mock interviews & LinkedIn optimization for career changers.
- **Target Users**: General users / career changers
- **Pricing**: Free (no waitlist; live product)

Used the existing table format (Name | Description | Links | Fees). Checked for duplicates — not previously listed.

Disclosure: submitting on behalf of the tool.