### PR TITLE
Add PlateSnap to AI Image Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | ControlNet |ControlNet is a neural network structure to control diffusion models by adding extra conditions.|[Github](https://github.com/lllyasviel/ControlNet) ![GitHub Repo stars](https://img.shields.io/github/stars/lllyasviel/ControlNet?style=social)|Free|
 | PixelPanda | AI-powered platform that creates professional product photos, marketing images, UGC-style videos, and AI avatars — no camera or studio needed. | [URL](https://pixelpanda.ai) | Free/Paid |
 | Topaz Photo AI | AI-powered image enhancement suite for photographers. Includes upscaling, noise reduction, sharpening, and face recovery in a single local desktop workflow. | [URL](https://www.topazlabs.com/topaz-photo-ai) | Paid/Trial |
+| PlateSnap | AI food photography for restaurants: turn one real dish photo into menu-, delivery-, and social-ready images. | [URL](https://platesnap.app) | Free/Paid |
 
 ### Video Creation
 


### PR DESCRIPTION
Following the recommendation template from #233:

- **Tool Name & URL**: PlateSnap — https://platesnap.app
- **Core Features**: Turns one real photo of a dish into professional food-marketing images: menu photos, delivery-app tiles (sized for DoorDash / Uber Eats / Grubhub), social posts, and seasonal promos. 30 photography styles, camera-angle control (overhead / 45° / side), output up to 4K with a commercial license.
- **Key Differentiators**: Built around recurring marketing content — you set a style once and every future dish photo comes back matching it, so a whole month of content stays visually consistent. Food-specific (not a generic product-photo tool), and the lowest monthly entry price among dedicated AI food-photography tools.
- **Target Users**: General Users (restaurant, café, and bakery owners), Content Creators
- **Getting Started**: 5 free credits, no card required — https://platesnap.app/generate ; written guide: https://platesnap.app/blog/professional-food-photography
- **Pricing**: Freemium — 5 free credits, paid plans from $10/month (20 photos).
- **Other**: Disclosure: I'm the founder of PlateSnap. The added line follows the existing 4-column table format of the "AI Image Creation" section; happy to also mirror the row in README-CN.md and add a CHANGELOG entry if you'd like — just say the word.