### PR TITLE
Add VideoGen to Video Creation

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -289,6 +289,7 @@
 | 即梦AI|字节跳动旗下的文生图、AI视频生成和AI图片编辑应用|[URL](https://jimeng.jianying.com/ai-tool/home)|免费/付费|
 | 剪映 |字幕生成语音、语音生成字幕、字幕翻译、一键图文成片，还有很便捷、强大的视频剪辑功能<br>识别字幕是vip功能|[URL](https://www.capcut.cn/)|免费/付费|
 | 通义万相 | 阿里旗下AI图片和视频创作应用| [URL](https://tongyi.aliyun.com/wanxiang/videoCreation) | 免费/付费 |
+| VideoGen | YC投资的AI视频生成工具，输入提示词、脚本或文章即可生成带AI配音、字幕和素材的完整视频，支持Sora、Veo、Kling等模型 | [URL](https://videogen.io/ai-video-generator) | 免费/付费 |
 | 海螺AI| Minimax的AI视频生成平台|[URL](https://hailuoai.com/video)|免费/付费|
 | 快手可灵|支持文生视频和图生视频、首尾帧、动作控制功能|[URL](https://kling.kuaishou.com/)|免费/付费|
 | PixVerse | 利用文本和照片创建令人惊叹的人工智能视频 |[URL](https://app.pixverse.ai/)|付费/试用|

--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | pixverse | Create Amazing AI Videos from Text & Photos |[URL](https://app.pixverse.ai/)|Paid/Free trial|
 | Pika | Text/Image to video |[URL](https://pika.art/home)|Paid/Free trial|
 | Fliki | A website that converts text into audio and video | [URL](https://fliki.ai) | Free/Paid |
+| VideoGen | Y Combinator-backed AI video generator. Turns a prompt, script, or article into a complete video with AI voiceover, subtitles, and b-roll. Generates footage with Sora, Veo, Kling and other models | [URL](https://videogen.io/ai-video-generator) | Free/Paid |
 | d-id | Generate digital human dubbing video based on text | [URL](https://studio.d-id.com) | Paid/Free trial|
 | HeyGen | Generate digital human dubbing video based on text | [URL](https://app.heygen.com/) | Paid/Free trial|
 |vivago.ai/video|Text to Video; Image to Video; 4K enhance|[URL](https://vivago.ai/video)|Free|


### PR DESCRIPTION
Adds VideoGen to the Video Creation section (both README.md and README-CN.md).

Following the recommendation template (#233):

- **Tool Name & URL**: VideoGen — https://videogen.io/ai-video-generator
- **Core Features**: Y Combinator-backed AI video generator. Turns a prompt, script, or article into a complete multi-scene video with AI voiceover, timed subtitles, b-roll, and background music; built-in timeline editor; generates footage with Sora, Veo, Kling, Seedance, Wan, Hailuo, and PixVerse; exports 9:16 / 1:1 / 16:9 for TikTok, Reels, Shorts, and YouTube. Open developer API (https://docs.videogen.io).
- **Key Differentiators**: Produces a finished, editable multi-scene video (script → voiceover → subtitles → b-roll) rather than a single clip, with the leading video models selectable per scene in one place.
- **Target Users**: Content creators / marketers / faceless-channel builders / developers
- **Getting Started**: https://videogen.io/ai-video-generator
- **Pricing**: Free plan; paid plans from $12/mo — listed as `Free/Paid`.
- **Other**: 40+ languages for voiceover and subtitles; no affiliate link.
