### PR TITLE
将 Jacobian 加入学术科研工具（中英文）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Awesome AI Tools list will be documented in this file.
 
 ## August 2026
+- Added Jacobian to the Academic research section (both EN/CN)
 - Added OpenConnector (oomol-lab/open-connector) to Office Collaboration CLI/MCP section (both EN/CN)
 
 ## July 2026

--- a/README-CN.md
+++ b/README-CN.md
@@ -455,6 +455,7 @@
 | 名称 | 说明 | 链接 | 费用 |
 | --- | --- | --- | --- |
 | Lean 4 | 交互式定理证明器 and 函数式编程语言，是 AI 形式化数学研究和自动定理证明的核心基础设施（如 DeepMind 的 AlphaProof 和 DeepSeek-Prover 均基于此）。 | [Github](https://github.com/leanprover/lean4) ![GitHub Repo stars](https://img.shields.io/github/stars/leanprover/lean4?style=social) | 免费 |
+| Jacobian | 面向可组合数学的 MCP 服务器、CLI 和 Python 库，支持跨多项式映射、线性代数与图算法进行精确计算和猜想检验。 | [Github](https://github.com/morluto/jacobian) ![GitHub Repo stars](https://img.shields.io/github/stars/morluto/jacobian?style=social) | 免费 |
 | AMiner | AI赋能科技情报挖掘，提供学术搜索、论文检索、专利、文献追踪、学者画像等功能 |[URL](https://www.aminer.cn/)|免费|
 |gpt_academic|为GPT/GLM提供图形交互界面，特别优化论文阅读润色体验，模块化设计支持自定义快捷按钮&函数插件，支持代码块表格显示，Tex公式双显示，新增Python和C++项目剖析&自译解功能，PDF/LaTex论文翻译&总结功能，支持并行问询多种LLM模型，支持清华chatglm等本地模型。兼容llama,rwkv,盘古大模型等。|[GitHub](https://github.com/binary-husky/gpt_academic) ![GitHub Repo stars](https://img.shields.io/github/stars/binary-husky/gpt_academic?style=social)|免费|
 |alphaxiv|一个基于arXiv平台的开放学术讨论社区，允许用户通过替换论文链接域名（arxiv.org替换为alphaxiv.org）直接在论文页面上进行逐行评论、提问和实时互动。并提供了 Ask AI 和 AI 生成文章博客等 AI 功能|[URL](https://www.alphaxiv.org/)|免费|

--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | Name | Description | Links | Fees |
 | --- | --- | --- | --- |
 | Lean 4 | An interactive theorem prover and functional programming language, serving as the core infrastructure for formal AI research and automated theorem proving (e.g., AlphaProof, DeepSeek-Prover). | [Github](https://github.com/leanprover/lean4) ![GitHub Repo stars](https://img.shields.io/github/stars/leanprover/lean4?style=social) | Free |
+| Jacobian | MCP server, CLI, and Python library for composable mathematics, with exact computation and conjecture testing across polynomial maps, linear algebra, and graph algorithms. | [Github](https://github.com/morluto/jacobian) ![GitHub Repo stars](https://img.shields.io/github/stars/morluto/jacobian?style=social) | Free |
 | AMiner | AI-powered academic research and tech intelligence platform providing paper search, patent search, literature tracking, and scholar profiling | [URL](https://www.aminer.cn/)| Free |
 | alphaxiv | An open academic discussion community based on the arXiv platform that allows users to comment line-by-line, ask questions, and interact in real-time by replacing the paper's linking domain (arxiv.org for alphaxiv.org) directly on the paper's page. And provides AI features such as Ask AI and AI-generated article blogs | [URL](https://www.alphaxiv.org/)| Free |
 


### PR DESCRIPTION
## 变更

在 Academic research / 学术科研分类中加入 Jacobian，并同步更新英文与简体中文 README；同时在 CHANGELOG.md 增加一条记录。除此之外没有修改其他内容。

## 项目简介

Jacobian 是一个面向可组合数学的 MCP 服务器、CLI 和 Python 库，支持跨多项式映射、线性代数与图算法进行精确计算和猜想检验。

## 收录理由

该分类已经收录 Lean 4 等数学与科研工具。Jacobian 提供可直接运行的数学计算入口，既能作为 Python 库使用，也能通过 MCP 让 AI Agent 调用，适合学术研究和数学实验工作流。

## 使用

```bash
npx -y jacobian mcp
```

许可证：MIT

## 验证

- `git diff --check`