### PR TITLE
Add PromptSpend to LLM Leaderboard section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Awesome AI Tools list will be documented in this file.
 
 ## August 2026
+- Added PromptSpend to LLM Leaderboard section (both EN/CN)
 - Added Grok Image to AI Image Creation section (both EN/CN)
 - Updated Seedance from 2.0 to 2.5 in READMEs and docs (both EN/CN)
 - Updated 豆包 / Dola flagship model from Doubao-1.5-pro to Doubao-Seed-2.1 Pro (both EN/CN)

--- a/README-CN.md
+++ b/README-CN.md
@@ -137,6 +137,7 @@
 |LiveCodeBench|LiveCodeBench 是一个全面且无污染的 LLM 代码评估基准，它会持续收集新的问题。LiveCodeBench 尤其关注更广泛的代码相关功能，例如自我修复、代码执行和测试输出预测，而不仅仅是代码生成。 |[URL](https://livecodebench.github.io/leaderboard.html)|免费|
 |StructEval|StructEval 是发表于 TMLR 2025 的评测基准与公开排行榜，用于评估 LLM 的结构化输出生成和转换，包含 2,035 个样例和 18 种文本及可渲染格式，并采用格式专用的结构与视觉检查。|[排行榜](https://tiger-ai-lab.github.io/StructEval/) [论文](https://openreview.net/forum?id=buDwV7LUA7) [Github](https://github.com/TIGER-AI-Lab/StructEval)|免费|
 |BenchGecko|AI模型基准测试排行榜，跨供应商定价对比，AI经济仪表盘。追踪数千个AI模型、128个评估基准、数百个供应商。提供免费API和开放数据集。|[URL](https://benchgecko.ai/zh/)|免费|
+|PromptSpend|对比LLM API定价，每条价格均标注来源和确认日期，并提供免费、无需密钥的API。|[URL](https://promptspend.com/)|免费|
 
 ### AI Agent
 | 名称 | 说明 | 链接 | 费用 |

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 |LLM Stats|LLM Stats, the most comprehensive LLM leaderboard, benchmarks and compares API models using daily‑updated, open‑source community data on capability, price, speed, and context length.|[URL](https://llm-stats.com/)|Free|
 |Price Per Token|Compare LLM API pricing across 200+ models from OpenAI, Anthropic, Google, and more. Includes token counters, cost calculators, and benchmark comparisons.|[URL](https://pricepertoken.com/)|Free|
 |BenchGecko|The data layer of the AI economy. AI model benchmark leaderboard with cross-provider pricing comparison across hundreds of providers. Tracks thousands of models across 128 benchmarks, AI economy indicators, agent leaderboard, and MCP server directory. Free API.|[URL](https://benchgecko.ai/)|Free|
+|PromptSpend|Compares LLM API pricing with a source and confirmation date on every entry, plus a free, keyless API.|[URL](https://promptspend.com/)|Free|
 
 ### AI Agent
 | Name | Description | Links | Fees |


### PR DESCRIPTION
Adds PromptSpend to the LLM Leaderboard section in both README.md and README-CN.md, following the existing 4-column table format (matches the Price Per Token / LLM Stats / BenchGecko rows).

PromptSpend is an open-source (MIT) LLM API pricing comparison tool. Every price is sourced and dated, and it offers a free, keyless API.

- Added row to README.md and README-CN.md
- Ran `python3 scripts/format_readmes.py`
- Added CHANGELOG.md entry under August 2026
- Verified https://promptspend.com/ resolves (200)