### PR TITLE
Add Resume Roaster to Writing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | Notion AI | AI-assisted note-taking software | [URL](https://www.notion.so)| with certain free AI trials, AI features $10/month |
 | Obsidian | Powerful local-first markdown note-taking tool with extensive AI plugin ecosystem - supports AI summarization, RAG, and intelligent note processing via community plugins | [URL](https://obsidian.md/) | Free/Paid|
 | Deep L Write | English and German writing tools to fix writing errors and rewrite sentences promptly. | [URL](https://www.deepl.com/write) | Free version to use with text word limit / paid upgrade available |
+| Resume Roaster | AI-powered resume critique and ATS scoring tool. Upload your resume, get a brutally honest AI critique, ATS keyword gap analysis, and improvement suggestions against any job description. | [URL](https://resume.roastlabai.com) | Free/Paid |
 
 
 ### Translation


### PR DESCRIPTION
Hi! I would like to add **Resume Roaster** to the Writing section.

[Resume Roaster](https://resume.roastlabai.com) is an AI-powered writing analysis tool for resumes:
- Provides detailed AI critique on resume writing quality
- Analyzes ATS compatibility and keyword coverage
- Suggests specific writing improvements
- Free tier available

It fits in the Writing section as a specialized AI writing feedback tool for career documents. Thanks for maintaining this comprehensive list!