### PR TITLE
docs: add DSH Plugin Store to Harness resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Awesome AI Tools list will be documented in this file.
 
 ## August 2026
+- Added DSH Plugin Store to the DeepSeek Harness related resources (both EN/CN)
 - Updated Grok Image URL to https://grok.com/imagine (both EN/CN)
 - Added Pi (earendil-works/pi) to AI Agent section with documentation in `docs/pi/` (both EN/CN)
 - Updated DeepSeek V4 Open Source LLM entry to mention MIT license, Hybrid Attention (CSA+HCA), mHC, Muon optimizer, three reasoning effort modes (Non-think / Think High / Think Max), and that Pro-Max is the current top open-source model on coding/agentic benchmarks (both EN/CN)

--- a/docs/deepseek-harness/README-CN.md
+++ b/docs/deepseek-harness/README-CN.md
@@ -90,6 +90,7 @@ pnpm dsh web
 ## 相关资源
 
 - [GitHub 仓库](https://github.com/deepseek-ai/deepseek-harness)
+- [DSH Plugin Store](https://github.com/sandbaseai/dsh-plugin-store) — 原生集成到 Settings 的社区插件市场，支持搜索、筛选、安装与已加载插件查看，并提供可复现的预览版和 Agent 目录工具。
 - [架构文档（上游）](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/architecture.md)
 - [Cordis 入门（上游）](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/cordis-primer.md)
 - [Agent 生命周期（上游）](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/agent-lifecycle.md)

--- a/docs/deepseek-harness/README.md
+++ b/docs/deepseek-harness/README.md
@@ -90,6 +90,7 @@ See `docs/architecture.md` in the upstream repo for the canonical subsystem diag
 ## Related Resources
 
 - [GitHub Repository](https://github.com/deepseek-ai/deepseek-harness)
+- [DSH Plugin Store](https://github.com/sandbaseai/dsh-plugin-store) — Native Settings marketplace for searching, filtering, installing, and inspecting community plugins; includes a reproducible preview release and agent-facing catalog tools.
 - [Architecture documentation (upstream)](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/architecture.md)
 - [Cordis primer (upstream)](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/cordis-primer.md)
 - [Agent lifecycle (upstream)](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/agent-lifecycle.md)


### PR DESCRIPTION
## Tool recommendation

- **Tool Name & URL**: [DSH Plugin Store](https://github.com/sandbaseai/dsh-plugin-store)
- **Core Features**: A native DeepSeek Harness Settings marketplace for searching and filtering the live community catalog, installing runtime-verified npm plugins into the local Web profile, inspecting loaded Cordis plugins, and exposing catalog search to agents.
- **Key Differentiators**: Runs as a native DSH plugin rather than a separate directory page; keeps one-click installation behind runtime-verification and npm-spec checks; publishes an immutable preview tarball with a recorded SHA-256 and an rc.8 profile boot smoke test.
- **Target Users**: Developers & Programmers / Enterprise Users
- **Getting Started**: [Preview installation and architecture](https://github.com/sandbaseai/dsh-plugin-store#try-the-preview) · [Preview 5 release](https://github.com/sandbaseai/dsh-plugin-store/releases/tag/v0.1.0-preview.5)
- **Pricing**: Free and open source (MIT).
- **Other**: This PR adds the resource only to the existing bilingual DeepSeek Harness deep-dive and records it in the August changelog. It does not change the main recommendation tables.

## Validation

- `git diff --check`
- English and Chinese entries are kept in sync
- GitHub API confirms the linked repository is public
- Repository link check passes in CI

## Disclosure

Submitted from the SandbaseAI organization, which maintains the linked project. This is a documentation-only self-submission to the existing DeepSeek Harness resource page.