### PR TITLE
Add Recast to General LLM Applications

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -251,6 +251,7 @@
 |together.ai chat|与 HuggingChat 类似，可选择不同的开源模型，支持 DeepSeek R1、LLaMA、QWen 和 Flux Schnell。每天 60 条免费信息。|[URL](https://chat.together.ai/)|免费/付费|
 |OpenRouter| 集成了 400 余种 AI 模型（OpenAI、Anthropic、Google、Mistral 等）的统一 API 网关。零加价定价，推理流量仅收取 5% 服务费，支持智能路由 / 故障转移|[URL](https://openrouter.ai/)| 免费/付费 |
 | IMA |腾讯推出的 AI 智能工作台，集成搜索、阅读、写作、知识库管理等功能。搜索覆盖微信公众号文章，支持上传本地文件、公众号文章或网页链接构建个人知识库。内置模型支持 DeepSeek-V4-Flash、GLM-5.2 和混元 Hy3。|[URL](https://ima.qq.com/) |免费|
+| Recast | 浏览器端工具，把杂乱的 LLM 输出修成合法 JSON，并列出每一处改动。全部在本地运行，不会上传任何内容。 | [URL](https://recast-indol.vercel.app/) | 免费/付费 |
 
 ### 办公协作CLI/MCP
 | 名称 | 说明 | 链接 | 费用 |

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | OmniRoute | Self-hostable AI gateway with 4-tier automatic fallback routing across 36+ providers. OpenAI-compatible API with quota tracking and zero-cost fallback to free tiers. | [GitHub](https://github.com/diegosouzapw/OmniRoute) <br> ![GitHub Repo stars](https://img.shields.io/github/stars/diegosouzapw/OmniRoute?style=social) | Free |
 | Morphik.ai | Open source AI-driven search engine for private documents | [URL](https://morphik.ai) [Github](https://github.com/morphik-org/morphik-core) ![GitHub Repo stars](https://img.shields.io/github/stars/morphik-org/morphik-core?style=social)| Free |
 | Future AGI | Open-source platform to simulate, evaluate, trace, guardrail, route, and optimize LLM and AI agent apps in one feedback loop, so agents don't just get monitored, they self-improve. Self-hostable. Apache-2.0. | [Github](https://github.com/future-agi/future-agi) ![GitHub Repo stars](https://img.shields.io/github/stars/future-agi/future-agi?style=social) | Free |
+| Recast | Browser tool that turns messy LLM output into valid JSON and lists every change. Runs entirely client-side; nothing is uploaded. | [URL](https://recast-indol.vercel.app/) | Free/Paid |
 
 ### Office Collaboration CLI/MCP
 | Name | Description | Links | Fees |


### PR DESCRIPTION
Adds [Recast](https://recast-indol.vercel.app/) under **General LLM Applications** (and the matching Chinese section).

Recast is a client-side browser tool that turns messy LLM output into valid JSON and lists every change. Nothing is uploaded.

- Name: Recast
- Description: Browser tool that turns messy LLM output into valid JSON and lists every change. Runs entirely client-side; nothing is uploaded.
- Link: https://recast-indol.vercel.app/
- Fees: Free/Paid

Related to the standing invite in #233.