### PR TITLE
[codex] Add Cadre to Video Creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Awesome AI Tools list will be documented in this file.
 
 ## August 2026
+- Added Cadre to the Video Creation section (both EN/CN)
 - Updated IndexTTS entry to IndexTTS-2.5 with 5-language support, emotion/speed/pronunciation control, and vLLM deployment notes (both EN/CN)
 - Updated Gemini flagship from Gemini 3.6 Flash to Gemini 3.7 Flash across AI Chatbot, Google AI Studio, and Antigravity entries/docs (both EN/CN)
 - Updated GLM flagship from GLM-5.2 to GLM-5.3 across AI Chatbot and IMA entries (both EN/CN where applicable)

--- a/README-CN.md
+++ b/README-CN.md
@@ -311,6 +311,7 @@
 | 豆包 | 字节跳动旗下的AI视频创作助手，支持文生视频、图生视频、数字人视频等多种功能 |[URL](https://www.doubao.com/) |免费/付费|
 | 即梦AI|字节跳动旗下的文生图、AI视频生成和AI图片编辑应用|[URL](https://jimeng.jianying.com/ai-tool/home)|免费/付费|
 | 剪映 |字幕生成语音、语音生成字幕、字幕翻译、一键图文成片，还有很便捷、强大的视频剪辑功能<br>识别字幕是vip功能|[URL](https://www.capcut.cn/)|免费/付费|
+| Cadre | 面向 Apple 芯片 Mac 的屏幕录制与时间线视频编辑工具。可录制或导入素材，完成剪切、电影级缩放和本地字幕，并通过本地 MCP 服务器让 Codex、Claude Code 等智能体控制编辑器。 | [URL](https://cadre.cam/) | 免费/付费 |
 | 通义万相 Wan 3.0 | 阿里通义万相全能参考视频生成模型，支持文本、图片、视频、音频、文档、PPT、网页等多模态参考输入，最高 20 个素材参考，单次直出最长 30 秒视频，具备像素级一致性保持和精准视频编辑能力 | [URL](https://tongyi.aliyun.com/wanxiang/videoCreation) | 免费/付费 |
 | 海螺AI| Minimax的AI视频生成平台|[URL](https://hailuoai.com/video)|免费/付费|
 | 快手可灵|支持文生视频和图生视频、首尾帧、动作控制功能|[URL](https://kling.kuaishou.com/)|免费/付费|

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | hailuoai|AI Video Creation Tool by Minimax|[URL](https://hailuoai.com/video)|Free/Paid|
 | Dream Machine|By Luma AI. Dream Machine is an AI model that makes high quality, realistic videos fast from text and images.[Official introductory video](https://www.youtube.com/watch?v=Zb3tffmBPRE)|[URL](https://lumalabs.ai/dream-machine)|Free/Paid|
 | capcut | Subtitle-generated speech, speech recognition, and very convenient and powerful video editing|[URL](https://www.capcut.com/)|Free/Paid|
+| Cadre | AI-directed screen recorder and timeline video editor for Apple Silicon Macs. Records or imports footage, applies cuts, cinematic zooms and on-device captions, and exposes the editor over a local MCP server for agents such as Codex and Claude Code. | [URL](https://cadre.cam/) | Free/Paid |
 | Runway | AI video generation and editing platform. Current Gen-4/Gen-4.5 models support text-to-video, image-to-video, video-to-video, motion brush, and advanced cinematic controls. | [URL](https://runwayml.com/) | Paid/Free trial|
 | pixverse | Create Amazing AI Videos from Text & Photos |[URL](https://app.pixverse.ai/)|Paid/Free trial|
 | Pika | Text/Image to video |[URL](https://pika.art/home)|Paid/Free trial|


### PR DESCRIPTION
## Recommendation template

- **Tool Name & URL**: [Cadre](https://cadre.cam/)
- **Core Features**: Records or imports screen footage, provides non-destructive timeline editing, cuts, cinematic zooms, cursor treatment, on-device captions, styling, audio mixing, preview, and MP4 export. A local MCP server lets compatible agents operate the same editor.
- **Key Differentiators**: Apple Silicon-native screen recording and timeline editing in one local app; on-device Whisper captions; and a documented 57-tool local MCP interface for agents such as Codex and Claude Code.
- **Target Users**: Content Creators / Designers / Developers & Programmers / Enterprise Users
- **Getting Started**: [Product and download](https://cadre.cam/), [agent integration guide](https://cadre.cam/agents.html), and [Agent API documentation](https://cadre.cam/docs/agent-api/overview.html)
- **Pricing**: Recording, editing, captioning, and preview are free. Exporting an MP4 requires a paid subscription.
- **Other**: Cadre currently requires an Apple Silicon Mac running macOS 13 or later. [First-party MCP handshake and tool-discovery evidence](https://cadre.cam/agent-api-evidence.html) is available.

## Disclosure

This is a self-submission for Cadre. The patch and this PR description were prepared with AI assistance and reviewed against the current live product pages.

The linked evidence is published by Cadre rather than an independent certification. Its stated scope is the signed rc.18 build's local MCP handshake and historical 54-tool discovery; it does not claim to test the current 57-tool surface, editing, caption generation, export, or model reasoning quality.

## Changes

- add Cadre to the English Video Creation table
- add the matching Chinese entry to the AI视频创作 table
- record the addition in the August 2026 changelog

## Validation

- ran `python3 scripts/format_readmes.py` and confirmed a second run is idempotent
- ran `git diff --check`
- confirmed exactly one four-column Cadre row in each README
- confirmed all four Cadre links above return HTTP 200
