### PR TITLE
Add FCaptcha to AI Detection

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -482,6 +482,7 @@
 | 名称 | 说明 | 链接 | 费用 |
 | --- | --- | --- | --- |
 | AI Detect Lab | 针对 Midjourney v7 和 Flux 优化的专业 AI 图像及 Deepfake 检测工具，提供高精度鉴别服务。 | [URL](https://www.aidetectlab.com/) | 免费 |
+| FCaptcha | 开源自托管验证码，检测的是 AI 智能体而非 AI 生成内容——包括截图点击的视觉智能体，以及通过 Chrome DevTools Protocol 驱动真实浏览器的计算机操作智能体。兼容 reCAPTCHA/Turnstile/hCaptcha 的 siteverify 接口，无需识别图片。提供 Go、Python、Node 三种服务端实现；MIT 协议。 | [GitHub](https://github.com/WebDecoy/FCaptcha) [演示](https://webdecoy.com/product/fcaptcha-demo/) | 免费 |
 
 ### 人形机器人
 | 名称 | 说明 | 链接 | 费用 |

--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | Name | Description | Links | Fees |
 | --- | --- | --- | --- |
 |AI Detect Lab|Professional AI image and Deepfake detection tool optimized for Midjourney v7 and Flux, offering high-precision identification services.|[URL](https://www.aidetectlab.com/)|Free|
+|FCaptcha|Open source, self-hosted CAPTCHA that detects AI *agents* rather than AI-generated content — vision agents that screenshot-and-click, and computer-use agents driving a real browser over the Chrome DevTools Protocol. Drop-in for the reCAPTCHA/Turnstile/hCaptcha siteverify API, with no image puzzle to solve. Go, Python and Node servers; MIT.|[GitHub](https://github.com/WebDecoy/FCaptcha) [Demo](https://webdecoy.com/product/fcaptcha-demo/)|Free|
 
 ### Humanoid Robots
 | Name | Description | Links | Fees |


### PR DESCRIPTION
- **Tool Name & URL**: FCaptcha — https://github.com/WebDecoy/FCaptcha
- **Core Features**: Open source, self-hosted CAPTCHA that detects automated traffic and AI agents — vision agents that screenshot-and-click, and computer-use agents driving a real browser over the Chrome DevTools Protocol. Also covers headless browsers, automation frameworks and CAPTCHA farms.
- **Key Differentiators**: Detects AI *agents* rather than AI-generated content, so it complements the existing entry in this section rather than overlapping it. Drop-in for the reCAPTCHA/Turnstile/hCaptcha `siteverify` API, and there is no image puzzle to solve.
- **Target Users**: Developers & Programmers / Enterprise Users
- **Getting Started**: [Live demo](https://webdecoy.com/product/fcaptcha-demo/) · [README](https://github.com/WebDecoy/FCaptcha#readme)
- **Pricing**: Free (MIT). Go, Python and Node server implementations.

Added to both `README.md` and `README-CN.md`.