### PR TITLE
cleanup(video-creation): restore OpenMontage on feature branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the Awesome AI Tools list will be documented in this file.
 
 ## August 2026
-- Removed low-influence tools from Video Creation section: Fliki, d-id (EN only); vivago.ai/video, OpenMontage (both EN/CN); kept Palmier Pro as a representative open-source video editor
+- Removed low-influence tools from Video Creation section: Fliki, d-id (EN only); vivago.ai/video (both EN/CN); kept Palmier Pro and OpenMontage as representative open-source video tools
 - Added Hugging Face to AI Infrastructure Platform section (formerly AI Cloud Platform), marked with 🌟, and added documentation in `docs/huggingface/` (both EN/CN)
 - Renamed section from AI Cloud Platform to AI Infrastructure Platform (both EN/CN)
 - Updated Qwen3 Open Source LLMs entry to Qwen3 / Qwen3.8, adding Qwen3.8-27B dense vision-language model details (both EN/CN)

--- a/README-CN.md
+++ b/README-CN.md
@@ -322,6 +322,7 @@
 | HeyGen | 根据文字生成数字人的配音视频 | [URL](https://app.heygen.com/) | 免费试用/付费 |
 | Palmier Pro | 面向 AI 构建的开源 macOS 视频编辑器。结合专业时间线剪辑、AI 辅助工作流，以及 Seedance、Kling、Nano Banana Pro 等生成式图像/视频能力；支持 MCP，可让 Claude Code、Codex、Cursor 或内置 Agent 控制视频时间线。仅支持 Apple Silicon Mac。 | [Github](https://github.com/palmier-io/palmier-pro) ![GitHub Repo stars](https://img.shields.io/github/stars/palmier-io/palmier-pro?style=social) | 免费/付费 |
 | Topaz Video AI | AI视频增强、放大、去隔行、稳定、补帧、运动去模糊等专业视频修复工具，本地桌面端运行 |[URL](https://www.topazlabs.com/topaz-video-ai)|付费/试用|
+| OpenMontage | 开源的 Agentic 视频制作系统。将 AI 编程助手变成完整的视频工作室，提供 12 种制作流程（讲解视频、动画、纪录片蒙太奇等）、100+ 工具、提供商评分、预算治理和质量关卡。支持 Claude Code、Cursor、Codex、Windsurf 和 Copilot。 | [Github](https://github.com/calesthio/OpenMontage) ![GitHub Repo stars](https://img.shields.io/github/stars/calesthio/OpenMontage?style=social) | 免费/付费 |
 
 ### AI基础设施平台
 | 名称 | 说明 | 链接 | 费用 |

--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | HeyGen | Generate digital human dubbing video based on text | [URL](https://app.heygen.com/) | Paid/Free trial|
 | Palmier Pro | Open-source macOS video editor built for AI. Combines professional timeline editing with AI-assisted workflows, generative image/video features using models like Seedance, Kling, and Nano Banana Pro, plus MCP integration so agents such as Claude Code, Codex, Cursor, or the in-app agent can control the editing timeline. Apple Silicon Mac only. | [Github](https://github.com/palmier-io/palmier-pro) ![GitHub Repo stars](https://img.shields.io/github/stars/palmier-io/palmier-pro?style=social) | Free/Paid |
 | Topaz Video AI | AI-powered video enhancement, upscaling, deinterlacing, stabilization, frame interpolation, and motion deblur for professional video restoration. Runs locally on desktop. | [URL](https://www.topazlabs.com/topaz-video-ai) | Paid/Trial |
+| OpenMontage | Open-source agentic video production system. Turns AI coding assistants into a full video studio with 12 pipelines (explainer, animation, documentary montage, etc.), 100+ tools, provider scoring, budget governance, and quality gates. Works with Claude Code, Cursor, Codex, Windsurf, and Copilot. | [Github](https://github.com/calesthio/OpenMontage) ![GitHub Repo stars](https://img.shields.io/github/stars/calesthio/OpenMontage?style=social) | Free/Paid |
 
 ### AI Infrastructure Platform
 | Name | Description | Links | Fees |


### PR DESCRIPTION
Keep OpenMontage in Video Creation section (both EN/CN) as an open-source agentic video production representative. Only Fliki, d-id (EN) and vivago.ai/video (EN/CN) are removed.

Pushed to restore-openmontage branch for review instead of main.