### PR TITLE
Add PressPlayed to Text To Speech

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Awesome AI Tools list will be documented in this file.
 
 ## September 2026
+- Added PressPlayed to Text To Speech / 文字转语音 as a browser-based RSS listening application (both EN/CN)
 - Updated Claude flagship model from **Claude Opus 5** to **Claude Fable 5.1** / **Claude Mythos 5.1** in AI Chatbots section (both EN/CN)
 - Added Orca (stablyai/orca) to AI Agent section with documentation in `docs/orca/` (both EN/CN)
 

--- a/README-CN.md
+++ b/README-CN.md
@@ -402,6 +402,7 @@
 | ChatTTS |ChatTTS是专门为对话场景设计的文本转语音模型，例如LLM助手对话任务。它支持英文和中文两种语言。最大的模型使用了10万小时以上的中英文数据进行训练。官网：https://chattts.com/|[Github](https://github.com/2noise/ChatTTS)![GitHub Repo stars](https://img.shields.io/github/stars/2noise/ChatTTS?style=social)|免费|
 |FunAudioLLM/CosyVoice|阿里开源的TTS模型|[Github](https://github.com/FunAudioLLM/CosyVoice) ![GitHub Repo stars](https://img.shields.io/github/stars/FunAudioLLM/CosyVoice?style=social)|免费|
 |fish-speech|输入 10 到 30 秒的声音样本即可生成高质量的 TTS 输出|[Github](https://github.com/fishaudio/fish-speech) ![GitHub Repo stars](https://img.shields.io/github/stars/fishaudio/fish-speech?style=social)|免费|
+| PressPlayed | 基于浏览器的 RSS 阅读器，使用神经网络语音合成朗读各来源所提供的文章正文，并在连续播放队列中自动切换到下一篇。每天新生成的语音时长上限约为 2 小时；重播已缓存的音频不计入额度。在受支持的手机上可锁屏继续播放。 | [URL](https://pressplayed.com/) | 免费 |
 
 ### 音乐识别
 | 名称 | 说明 | 链接 | 费用 |

--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | Hailuo AI Text to Speech | Offer over 300 voices in 17 languages and multiple accents, covering a wide range of styles and age groups to provide the voice effects you need.|[URL](https://www.hailuo.ai/audio)|Limited-time Free|
 | elevenlabs | Intelligent AI Text to Speech. Current flagship **Eleven v3** (generally available). | [URL](https://elevenlabs.io/) | Free/Paid |
 | ChatTTS |ChatTTS is a text-to-speech model designed specifically for dialogue scenario such as LLM assistant. It supports both English and Chinese languages. Our model is trained with 100,000+ hours composed of chinese and english. Website：https://chattts.com/|[Github](https://github.com/2noise/ChatTTS)![GitHub Repo stars](https://img.shields.io/github/stars/2noise/ChatTTS?style=social)|Free|
+| PressPlayed | Browser-based RSS reader that uses neural TTS to narrate the article text each source makes available, automatically advancing through a continuous queue. New narration is limited to about 2 hours per day; replaying cached audio is unmetered. Lock-screen playback works on supported phones. | [URL](https://pressplayed.com/) | Free |
 
 ### Music Recognition
 | Name | Description | Links | Fees |


### PR DESCRIPTION
**Disclosure**: I work on PressPlayed.

- **Tool Name & URL**: PressPlayed — https://pressplayed.com/
- **Core Features**: Browser-based RSS reader / PWA that reads articles aloud using Microsoft Edge neural text-to-speech generated server-side. It reads the article text each source makes available, then automatically advances through a continuous listening queue. Users can add RSS feeds, import OPML, or follow publishers and topics.
- **Section Fit**: Neural text-to-speech is the product's core listening function: every queued article is turned into spoken audio server-side, rather than TTS being an optional add-on.
- **Key Differentiators**: Organized around recurring RSS/news sources and continuous listening rather than one-off pasted text, document uploads, summaries, or a TTS generation API. On supported phones, playback is built and tested to continue with the screen locked, though calls, battery restrictions, and other audio apps can still interrupt it. It does not summarize articles and does not bypass paywalls, sign-ins, or other publisher access controls.
- **Target Users**: General Users
- **Getting Started**: Product tour: https://pressplayed.com/tour.html ; RSS listening guide: https://pressplayed.com/listen-to-rss-feeds-aloud.html
- **Pricing**: Currently free. Accounts are limited to about two hours per day of newly generated narration; replaying cached audio does not count against that allowance. No credit card is required and there is currently no paid plan.
- **Other**: This change adds matching English and Chinese rows plus a changelog entry; it does not add a deep-dive document.