### PR TITLE
Add ScribeDrop to Speech Recognition section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Awesome AI Tools list will be documented in this file.
 
 ## September 2026
+- Added ScribeDrop to Speech Recognition section (both EN/CN)
 - Updated Claude flagship model from **Claude Opus 5** to **Claude Fable 5.1** / **Claude Mythos 5.1** in AI Chatbots section (both EN/CN)
 - Added Orca (stablyai/orca) to AI Agent section with documentation in `docs/orca/` (both EN/CN)
 

--- a/README-CN.md
+++ b/README-CN.md
@@ -391,6 +391,7 @@
 | 飞书秒记 | 上传视频或者音频可转录为文字，并可一键导出到飞书文档。处理速度很快，一个将近 2 个多小时的视频，约 6 分钟完成。 | [URL](https://www.feishu.cn/product/minutes)| 免费，有企业付费版|
 | 通义听悟 | 阿里旗下的语音转录应用 | [URL](https://tingwu.aliyun.com/) | 免费/付费 |
 |阿里云智能语音交互-语音识别API|试用版3个月免费试用期，录音文件识别免费额度:2小时/日|[URL](https://ai.aliyun.com/nls)|付费/免费试用|
+| ScribeDrop | 免费开源的 Windows Whisper 转录 GUI —— 拖入音视频文件，完全离线导出 TXT/SRT/VTT 字幕。 | [GitHub](https://github.com/DJsluxx/scribedrop) ![GitHub Repo stars](https://img.shields.io/github/stars/DJsluxx/scribedrop?style=social)| 免费 |
 
 ### 文字转语音
 | 名称 | 说明 | 链接 | 费用 |

--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | buzz | An open source desktop software based on OpenAI's Whisper to recognize speech and generate subtitles | [GitHub](https://github.com/chidiwilliams/buzz) <br> ![GitHub Repo stars](https://img.shields.io/github/stars/chidiwilliams/buzz?style=social)| Free |
 | WhisperDesktop| Open source, OpenAI-based Whisper, a desktop application for Windows, uses the GPU for processing, which will be faster than on the CPU with good GPU performance.|[GitHub](https://github.com/Const-me/Whisper) ![GitHub Repo stars](https://img.shields.io/github/stars/Const-me/Whisper?style=social)|Free|
 | whisperX | WhisperX: Automatic Speech Recognition with Word-level Timestamps (& Diarization)| [whisperX](https://github.com/m-bain/whisperX) ![GitHub Repo stars](https://img.shields.io/github/stars/m-bain/whisperX?style=social) |Free|
+| ScribeDrop | Free, open-source Windows GUI for offline Whisper transcription — drag in audio/video, export TXT/SRT/VTT locally. | [GitHub](https://github.com/DJsluxx/scribedrop) <br> ![GitHub Repo stars](https://img.shields.io/github/stars/DJsluxx/scribedrop?style=social)| Free |
 
 ### Text To Speech
 | Name | Description | Links | Fees |


### PR DESCRIPTION
Adds ScribeDrop to the Speech Recognition table (both README.md and README-CN.md), plus a CHANGELOG.md entry, following AGENTS.md conventions. Ran scripts/format_readmes.py — no formatting changes needed.

ScribeDrop is a free, MIT-licensed, offline Whisper transcription GUI for Windows — drag in audio/video, get TXT/SRT/VTT back, no cloud upload. Similar in spirit to buzz, already listed in this section.

**Disclosure:** I'm the project's maintainer/author, not a neutral third party.

Repo: https://github.com/DJsluxx/scribedrop (MIT license)