### PR TITLE
Add StudyArena to General LLM Applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Awesome AI Tools list will be documented in this file.
 
 ## September 2026
+- Added StudyArena to General LLM Applications for student answer comparisons (both EN/CN)
 - Updated the AI Image Creation entry from ChatGPT Images 2.0 / GPT Image 2.0 to 2.5 (~50% faster, Sketch feature, new GPT-Image-2.5 Flare/Sunburst API models) (both EN/CN)
 - Added Obscura (h4ckf0r0day/obscura) to AI Agent section: an open-source Rust headless browser engine for AI agents and web scraping, CDP-compatible drop-in replacement for headless Chrome (both EN/CN)
 - Updated ChatGPT flagship from GPT-5.6 Sol to GPT-6 Astra (both EN/CN)

--- a/README-CN.md
+++ b/README-CN.md
@@ -241,6 +241,7 @@
 |together.ai chat|与 HuggingChat 类似，可选择不同的开源模型，支持 DeepSeek R1、LLaMA、QWen 和 Flux Schnell。每天 60 条免费信息。|[URL](https://chat.together.ai/)|免费/付费|
 |OpenRouter| 集成了 400 余种 AI 模型（OpenAI、Anthropic、Google、Mistral 等）的统一 API 网关。零加价定价，推理流量仅收取 5% 服务费，支持智能路由 / 故障转移|[URL](https://openrouter.ai/)| 免费/付费 |
 | IMA |腾讯推出的 AI 智能工作台，集成搜索、阅读、写作、知识库管理等功能。搜索覆盖微信公众号文章，支持上传本地文件、公众号文章或网页链接构建个人知识库。内置模型支持 DeepSeek-V4-Flash、GLM-5.3 和混元 Hy4 preview。|[URL](https://ima.qq.com/) |免费|
+| StudyArena | 学生比较同一学习问题的三个匿名回答，投票后查看模型名称。 | [URL](https://studyarena.com) | 三模型对比免费；指定模型及六模型对比需付费 |
 
 ### 办公协作CLI/MCP
 | 名称 | 说明 | 链接 | 费用 |

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ This repo collects awesome AI tools. Welcome everyone to recommend more awesome 
 | OmniRoute | Self-hostable AI gateway with 4-tier automatic fallback routing across 36+ providers. OpenAI-compatible API with quota tracking and zero-cost fallback to free tiers. | [GitHub](https://github.com/diegosouzapw/OmniRoute) <br> ![GitHub Repo stars](https://img.shields.io/github/stars/diegosouzapw/OmniRoute?style=social) | Free |
 | Morphik.ai | Open source AI-driven search engine for private documents | [URL](https://morphik.ai) [Github](https://github.com/morphik-org/morphik-core) ![GitHub Repo stars](https://img.shields.io/github/stars/morphik-org/morphik-core?style=social)| Free |
 | Future AGI | Open-source platform to simulate, evaluate, trace, guardrail, route, and optimize LLM and AI agent apps in one feedback loop, so agents don't just get monitored, they self-improve. Self-hostable. Apache-2.0. | [Github](https://github.com/future-agi/future-agi) ![GitHub Repo stars](https://img.shields.io/github/stars/future-agi/future-agi?style=social) | Free |
+| StudyArena | Students compare three anonymous answers to a study question, vote, then reveal the models. | [URL](https://studyarena.com) | Free three-model comparisons; paid model choice and six-model comparisons |
 
 ### Office Collaboration CLI/MCP
 | Name | Description | Links | Fees |


### PR DESCRIPTION
I've been building StudyArena to help students compare explanations before seeing which AI model wrote each answer.

- **Tool Name & URL**: StudyArena, https://studyarena.com
- **Core Features**: Three anonymous answers to one study question, voting, and model reveal.
- **Key Differentiators**: A student-focused comparison flow that hides model names until after the vote.
- **Target Users**: Researchers & Students; the main audience is students.
- **Getting Started**: Enter a study question on the homepage, compare the answers, then vote to reveal the models.
- **Pricing**: The three-model flow is free. Supporter is $20/month and adds model choice and six-model comparisons.
- **Other**: This adds matching English and Chinese entries under General LLM Applications and the required changelog note.
